### PR TITLE
Correção de códigos de eventos do Intermediário da NFSe Nacional ()

### DIFF
--- a/src/OpenAC.Net.NFSe.Nacional/Common/Types/TipoEventoCod.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Types/TipoEventoCod.cs
@@ -94,7 +94,7 @@ public struct TipoEventoCod
     /// <summary>
     /// Rejeição pelo intermediário.
     /// </summary>
-    public const string RejeicaoIntermediario = "203207";
+    public const string RejeicaoIntermediario = "204207";
 
     /// <summary>
     /// Anulação da rejeição.


### PR DESCRIPTION
# Correção de códigos de eventos da NFSe Nacional

## Contexto

Os códigos dos eventos de **confirmação** e **rejeição pelo intermediário** utilizados na NFSe Nacional estavam divergentes da tabela oficial de eventos.
Isso poderia gerar XMLs com códigos incorretos, resultando em rejeição pelo serviço da NFSe Nacional ao registrar esses eventos.

## O que foi alterado

No arquivo `src/OpenAC.Net.NFSe.Nacional/Common/Types/TipoEventoCod.cs`:

1. Ajuste do código de **Confirmação pelo intermediário**:
   - Antes: `ConfirmacaoIntermediario = "203203";`
   - Depois: `ConfirmacaoIntermediario = "204203";`

2. Ajuste do código de **Rejeição pelo intermediário**:
   - Antes: `RejeicaoIntermediario = "203207";`
   - Depois: `RejeicaoIntermediario = "204207";`

## Impacto

- Garante que os eventos de confirmação e rejeição pelo intermediário sejam enviados com os códigos corretos conforme a especificação da NFSe Nacional.
- Evita possíveis rejeições de eventos nos web services por uso de código inválido.
- Alteração compatível com versões anteriores do código (backward compatible do ponto de vista de API), porém corrige o comportamento funcional.

## Como testar

1. Gerar um XML de evento de **Confirmação pelo intermediário** e verificar se o código utilizado é `204203`.
2. Gerar um XML de evento de **Rejeição pelo intermediário** e verificar se o código utilizado é `204207`.
3. (Opcional) Enviar esses eventos em um ambiente de homologação do provedor da NFSe Nacional para confirmar a aceitação com os novos códigos.
