### PR TITLE
 Adequação do modelo à regra de `choice` do XSD (`TCInfoDedRed`)

### DIFF
--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/ValoresDeducaoReducao.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/ValoresDeducaoReducao.cs
@@ -43,14 +43,14 @@ public sealed class ValoresDeducaoReducao
     /// <summary>
     /// Porcentagem de dedução ou redução.
     /// </summary>
-    [DFeElement(TipoCampo.De2, "pDR", Min = 4, Max = 6, Ocorrencia = Ocorrencia.Obrigatoria)]
-    public decimal Porcentagem { get; set; }
+    [DFeElement(TipoCampo.De2, "pDR", Min = 4, Max = 6, Ocorrencia = Ocorrencia.NaoObrigatoria)]
+    public decimal? Porcentagem { get; set; }
 
     /// <summary>
     /// Valor de dedução ou redução.
     /// </summary>
-    [DFeElement(TipoCampo.De2, "vDR", Min = 4, Max = 18, Ocorrencia = Ocorrencia.Obrigatoria)]
-    public decimal Valor { get; set; }
+    [DFeElement(TipoCampo.De2, "vDR", Min = 4, Max = 18, Ocorrencia = Ocorrencia.NaoObrigatoria)]
+    public decimal? Valor { get; set; }
 
     /// <summary>
     /// Lista de documentos de dedução ou redução.


### PR DESCRIPTION
### Adequação do modelo à regra de `choice` do XSD (`TCInfoDedRed`)

Este Pull Request ajusta a modelagem do grupo **Dedução/Redução do valor do serviço** para atender corretamente à definição do tipo complexo `TCInfoDedRed`, conforme especificado no XSD da NFSe Nacional.

#### 📌 Contexto

O tipo `TCInfoDedRed` é definido com `xs:choice`, o que implica que **apenas uma das opções pode ser informada por ocorrência**:

* `pDR` – Percentual de dedução/redução
* `vDR` – Valor monetário de dedução/redução
* `documentos` – Documentos que fundamentam a dedução/redução

Para que essa regra seja respeitada no modelo de dados, é necessário que os campos não sejam tratados como obrigatórios simultaneamente.

#### 🔧 Alterações realizadas

* As propriedades `pDR`, `vDR` foram alteradas para **nullable**, permitindo que apenas uma delas seja informada.
* O atributo **`DFeElement`** dessas propriedades foi ajustado para **`NaoObrigatorio`**, refletindo corretamente a semântica do `xs:choice` no schema.
