### PR TITLE
Correção no parse do campo "erro" na resposta da API ao enviar eventos.

### DIFF
--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaEnvioEvento.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaEnvioEvento.cs
@@ -29,8 +29,9 @@
 // <summary></summary>
 // ***********************************************************************
 
-using System.Text.Json.Serialization;
 using OpenAC.Net.NFSe.Nacional.Common.Converter;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace OpenAC.Net.NFSe.Nacional.Common.Model;
 
@@ -45,4 +46,19 @@ public sealed class RespostaEnvioEvento : RespostaBase
     [JsonPropertyName("eventoXmlGZipB64")]
     [JsonConverter(typeof(XmlGzipJsonConverter))]
     public string XmlEvento { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Propriedade alternativa para capturar "erro" do JSON quando a API retorna "erro" ao invés de "erros".
+    /// Não deve ser usada diretamente. Use a propriedade <see cref="RespostaBase.Erros"/> para acessar os erros.
+    /// </summary>
+    [JsonPropertyName("erro")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public List<MensagemProcessamento>? ErroAlternativo
+    {
+        set
+        {
+            if (value != null)
+                Erros = value;
+        }
+    }
 }

--- a/src/OpenAC.Net.NFSe.Nacional/Webservice/Nacional/NacionalWebservice.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Webservice/Nacional/NacionalWebservice.cs
@@ -32,6 +32,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using OpenAC.Net.Core.Logging;
 using OpenAC.Net.DFe.Core.Common;
@@ -217,8 +218,13 @@ public class NacionalWebservice : NFSeWebserviceBase
         GravarArquivoEmDisco(strResponse, $"Evento-{evento.Informacoes.ChNFSe}{evento.Informacoes.Evento}-resp.json",
             documento);
 
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        };
+
         return NFSeResponse<RespostaEnvioEvento>.Create(evento.Xml, strEnvio, strResponse,
-            httpResponse.IsSuccessStatusCode);
+            httpResponse.IsSuccessStatusCode, jsonOptions);
     }
 
     #endregion Eventos


### PR DESCRIPTION
-Adicionado ErroAlternativo ao RespostaEnvioEvento para suportar casos em que a API retorna um único campo "erro" ao invés de "erros". 
-Atualização do NacionalWebservice para usar a desserialização JSON que não diferencia maiúsculas de minúsculas ao fazer o parse da resposta do envio de eventos, pois a api retorna "codigo" e "descricao" no detalhamento dos erros