### PR TITLE
Correção na nomenclatura do enumerador

### DIFF
--- a/src/OpenAC.Net.NFSe.Nacional/Common/Types/RegimeApuracao.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Types/RegimeApuracao.cs
@@ -49,7 +49,7 @@ public enum RegimeApuracao
     /// Regime de apuração dos tributos federais pelo Simples Nacional e ISSQN por fora do Simples Nacional conforme legislação municipal.
     /// </summary>
     [DFeEnum("2")]
-    TributosFederaisSNISSQPorForaSN,
+    TributosFederaisSNISSQNPorForaSN,
 
     /// <summary>
     /// Regime de apuração dos tributos federais e municipal por fora do Simples Nacional conforme legislações federal e municipal.


### PR DESCRIPTION
⚠️ Breaking Change
O enumerador `TributosFederaisSNISSQPorForaSN` foi modificado.
Aplicações que utilizam esse enum podem precisar ser atualizadas, pois valores foram renomeados.
Recomendo revisar os pontos de uso antes de atualizar a versão.