### PR TITLE
Ajustar Código do Evento Rejeição Por Prestador

### DIFF
--- a/src/OpenAC.Net.NFSe.Nacional/Common/Types/TipoEventoCod.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Types/TipoEventoCod.cs
@@ -84,7 +84,7 @@ public struct TipoEventoCod
     /// <summary>
     /// Rejeição pelo prestador.
     /// </summary>
-    public const string RejeicaoPrestador = "203205";
+    public const string RejeicaoPrestador = "202205";
 
     /// <summary>
     /// Rejeição pelo tomador.


### PR DESCRIPTION
# fix: corrigir código de rejeição do prestador para o valor correto

## Resumo
Corrige o valor da constante `RejeicaoPrestador` em `TipoEventoCod` para o código correto.

## Alteração realizada
- Ajustado o valor de:
  - `RejeicaoPrestador = "203205"`
- Para:
  - `RejeicaoPrestador = "202205"`
  
  
<img width="844" height="48" alt="image" src="https://github.com/user-attachments/assets/8600be92-35fe-4040-a320-5ae23ffe5072" />


## Arquivo alterado
- `src/OpenAC.Net.NFSe.Nacional/Common/Types/TipoEventoCod.cs`

## Impacto
- Corrige o mapeamento do código do evento de rejeição pelo prestador.
- Reduz risco de inconsistência na interpretação do retorno da NFSe Nacional.
