### PR TITLE
fix: deserialização com RTCInfoDest -> CNPJ não funcionava

### DIFF
--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/RTCInfoDest.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/RTCInfoDest.cs
@@ -24,10 +24,11 @@ namespace OpenAC.Net.NFSe.Nacional.Common.Model;
 public sealed class RTCInfoDest
 {
     #region Choice
-    
+
     /// <summary>
     /// Número do CNPJ do Destinatário do serviço.
     /// </summary>
+    [DFeElement(TipoCampo.Str, "CNPJ", Ocorrencia = Ocorrencia.NaoObrigatoria)]
     public string? CNPJ { get; set; }
     /// <summary>
     ///  CPF (Cadastro de Pessoas Físicas).


### PR DESCRIPTION
# fix: corrigir erro realizar deserialização RTCInfoDest -> CNPJ

## Resumo
Corrigir erro realizar deserialização RTCInfoDest -> CNPJ

## Alteração realizada
- Ajustado o valor de:
  - `public string? CNPJ { get; set; }`
- Para:
  - `[DFeElement(TipoCampo.Str, "CNPJ", Ocorrencia = Ocorrencia.NaoObrigatoria)]
    public string? CNPJ { get; set; }`

## Arquivo alterado
- `src/OpenAC.Net.NFSe.Nacional/Common/Model/RTCInfoDest.cs`

## Impacto
- Corrige o mapeamento na deserialização do NFSe
- Reduz risco de inconsistência na interpretação do retorno da NFSe Nacional.
