### PR TITLE
Correção das tags do TCAtvEvento

### DIFF
--- a/src/OpenAC.Net.NFSe.Nacional.Test/.env.example
+++ b/src/OpenAC.Net.NFSe.Nacional.Test/.env.example
@@ -119,6 +119,35 @@ NfseModeloNovo2.CertificadoPath=C:\certificados\seu_certificado_novo2.pfx
 NfseModeloNovo2.CertificadoSenha=sua_senha_aqui
 
 # =============================================================================
+# PROVEDOR FIORILLI - Webservice SOAP (layout Nacional v1.00)
+# =============================================================================
+
+# Configuração para testes de emissão pelo provedor Fiorilli.
+# Usar: SetupOpenNFSeNacional.ConfigurarFiorilli(openNFSeNacional)
+# Testes: TestEmissaoFiorilli.EmissaoNFSeFiorilli / EmissaoNFSeFiorilliSemTomador
+#
+# OBS: o município Fiorilli NÃO está no arquivo embarcado Municipios.nfse; ele é
+# registrado em tempo de execução pelo setup usando o código e o endpoint abaixo.
+
+# Código IBGE do município atendido pela Fiorilli (7 dígitos)
+Fiorilli.CodMunIbge=3550308
+
+# Tipo de Inscrição Federal: 1=CPF, 2=CNPJ
+Fiorilli.TipoInscricaoFederal=2
+
+# CNPJ ou CPF do prestador (apenas números)
+Fiorilli.InscricaoFederal=12345678000100
+
+# Inscrição Municipal do prestador (obrigatória para cancelamento na Fiorilli)
+Fiorilli.InscricaoMunicipal=1234567
+
+# Caminho completo do certificado digital (.pfx)
+Fiorilli.CertificadoPath=C:\certificados\seu_certificado.pfx
+
+# Senha do certificado digital
+Fiorilli.CertificadoSenha=sua_senha_aqui
+
+# =============================================================================
 # TOMADORES DE SERVIÇO
 # =============================================================================
 
@@ -257,6 +286,7 @@ Tomador4.CodMunicipio=9999999
 #    ✓ ConfiguracaoModeloAtual2: v1.00 (Advocacia)
 #    ✓ ConfiguracaoModeloNovoCenario1: v1.01 (Geral)
 #    ✓ ConfiguracaoModeloNovoCenario2: v1.01 (IBS/CBS - Reforma Tributária)
+#    ✓ ConfigurarFiorilli: v1.00 (provedor Fiorilli - webservice SOAP)
 #
 # 7. TOMADORES ESTRANGEIROS:
 #    ✓ Identificados por CodMunicipio=9999999

--- a/src/OpenAC.Net.NFSe.Nacional.Test/OpenAC.Net.NFSe.Nacional.Test.csproj
+++ b/src/OpenAC.Net.NFSe.Nacional.Test/OpenAC.Net.NFSe.Nacional.Test.csproj
@@ -10,10 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove=".env" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -31,6 +27,17 @@
 
   <ItemGroup>
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Copia o .env (quando existir) para o diretório de saída, pois o setup dos testes
+         o carrega de AppContext.BaseDirectory (bin\Debug\<tfm>\). Sem isso, o arquivo criado
+         na raiz do projeto não é encontrado em tempo de execução.
+         O Remove evita item duplicado caso o glob padrão do SDK já inclua o .env. -->
+    <None Remove=".env" />
+    <None Include=".env" Condition="Exists('.env')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/OpenAC.Net.NFSe.Nacional.Test/SetupOpenNFSeNacional.cs
+++ b/src/OpenAC.Net.NFSe.Nacional.Test/SetupOpenNFSeNacional.cs
@@ -1,7 +1,11 @@
-﻿using DotNetEnv;
+﻿using System.Net;
+using DotNetEnv;
+using OpenAC.Net.DFe.Core.Collection;
+using OpenAC.Net.DFe.Core.Common;
 using OpenAC.Net.DFe.Core.Extensions;
 using OpenAC.Net.NFSe.Nacional.Common.Model;
 using OpenAC.Net.NFSe.Nacional.Common.Types;
+using OpenAC.Net.NFSe.Nacional.Webservice;
 
 namespace OpenAC.Net.NFSe.Nacional.Test;
 
@@ -187,6 +191,80 @@ public class SetupOpenNFSeNacional
         openNFSeNacional.Configuracoes.Geral.RetirarEspacos = true;
         openNFSeNacional.Configuracoes.Arquivos.PathSalvar = pathSalvar;
         openNFSeNacional.Configuracoes.Arquivos.PathSchemas = pathSchemas;
+    }
+
+    /// <summary>
+    /// Configuração para o provedor Fiorilli (SOAP), versão 1.00.
+    /// Lê as variáveis com prefixo "Fiorilli" do arquivo .env e registra o município
+    /// no <see cref="NFSeServiceManager"/> em tempo de execução (o recurso embarcado não traz Fiorilli).
+    /// </summary>
+    public static void ConfigurarFiorilli(
+        OpenNFSeNacional openNFSeNacional,
+        string numDps = "1",
+        string serieDps = "1",
+        string numEvento = "1")
+    {
+        NumDPS = numDps;
+        SerieDPS = serieDps;
+        NumEvento = numEvento;
+
+        CodMunIBGE = GetEnvOrThrow("Fiorilli.CodMunIbge");
+        TipoInscricaoFederal = int.Parse(GetEnvOrThrow("Fiorilli.TipoInscricaoFederal"));
+        InscricaoFederal = GetEnvOrThrow("Fiorilli.InscricaoFederal");
+        InscricaoMunicipal = GetEnvOrThrow("Fiorilli.InscricaoMunicipal");
+
+        var endpoint = Env.GetString("Fiorilli.Endpoint");
+        if (string.IsNullOrWhiteSpace(endpoint))
+            endpoint = "http://fi1.fiorilli.com.br:5663/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType";
+
+        var certificadoPath = GetEnvOrThrow("Fiorilli.CertificadoPath");
+        var certificadoSenha = GetEnvOrThrow("Fiorilli.CertificadoSenha");
+        var pathSalvar = GetEnvOrThrow("Geral.PathSalvar");
+
+        RegistrarMunicipioFiorilli(int.Parse(CodMunIBGE), endpoint);
+
+        var pathSchemas = Path.Combine(AppContext.BaseDirectory, "Schemas", VersaoNFSe.Ve101.GetDFeValue());
+        openNFSeNacional.Configuracoes.Geral.Versao = VersaoNFSe.Ve101;
+        openNFSeNacional.Configuracoes.Certificados.CertificadoBytes = File.ReadAllBytes(certificadoPath);
+        openNFSeNacional.Configuracoes.Certificados.Senha = certificadoSenha;
+        openNFSeNacional.Configuracoes.Geral.Salvar = true;
+        openNFSeNacional.Configuracoes.Geral.RetirarAcentos = true;
+        openNFSeNacional.Configuracoes.Geral.RetirarEspacos = true;
+        openNFSeNacional.Configuracoes.Arquivos.PathSalvar = pathSalvar;
+        openNFSeNacional.Configuracoes.Arquivos.PathSchemas = pathSchemas;
+        openNFSeNacional.Configuracoes.WebServices.Ambiente = DFeTipoAmbiente.Homologacao;
+        openNFSeNacional.Configuracoes.WebServices.CodigoMunicipio = int.Parse(CodMunIBGE);
+        openNFSeNacional.Configuracoes.WebServices.InscricaoMunicipal = InscricaoMunicipal;
+        openNFSeNacional.Configuracoes.WebServices.Protocolos = SecurityProtocolType.Tls12;
+    }
+
+    /// <summary>
+    /// Registra (uma única vez) o município Fiorilli no <see cref="NFSeServiceManager"/>,
+    /// apontando o endpoint SOAP em <see cref="TipoUrl.Enviar"/> para o ambiente de homologação.
+    /// </summary>
+    private static void RegistrarMunicipioFiorilli(int codigoMunicipio, string endpoint)
+    {
+        var services = NFSeServiceManager.Instance.Services;
+        if (services.Webservices.Any(x => x.Codigo == codigoMunicipio)) return;
+
+        services.Webservices.Add(new NFSeServiceInfo
+        {
+            Codigo = codigoMunicipio,
+            Provider = NFSeProvider.Fiorilli,
+            Nome = "Fiorilli (Teste)",
+            UF = DFeSiglaUF.SP,
+            Ambientes = new DFeCollection<NFSeEnvironment>
+            {
+                new NFSeEnvironment
+                {
+                    Ambiente = DFeTipoAmbiente.Homologacao,
+                    Enderecos = new Dictionary<TipoUrl, string>
+                    {
+                        { TipoUrl.Enviar, endpoint }
+                    }
+                }
+            }
+        });
     }
 
     private static string GetEnvOrThrow(string key)

--- a/src/OpenAC.Net.NFSe.Nacional.Test/TestEmissaoFiorilli.cs
+++ b/src/OpenAC.Net.NFSe.Nacional.Test/TestEmissaoFiorilli.cs
@@ -1,0 +1,237 @@
+using OpenAC.Net.NFSe.Nacional.Common.Model;
+using OpenAC.Net.NFSe.Nacional.Common.Types;
+
+namespace OpenAC.Net.NFSe.Nacional.Test;
+
+/// <summary>
+/// Testes de emissão simples de NFS-e pelo provedor Fiorilli (webservice SOAP).
+/// Requerem as variáveis com prefixo "Fiorilli" no arquivo .env (código do município,
+/// inscrições, certificado e, opcionalmente, o endpoint de homologação).
+/// </summary>
+[TestClass]
+public class TestEmissaoFiorilli
+{
+    /// <summary>
+    /// Emissão simples com tomador (operação recepcionarDps).
+    /// </summary>
+    [TestMethod]
+    public async Task EmissaoNFSeFiorilli()
+    {
+        var openNFSeNacional = new OpenNFSeNacional();
+        SetupOpenNFSeNacional.ConfigurarFiorilli(openNFSeNacional);
+
+        var prest = new PrestadorDps
+        {
+            CNPJ = SetupOpenNFSeNacional.InscricaoFederal,
+            InscricaoMunicipal = SetupOpenNFSeNacional.InscricaoMunicipal,
+            Email = "teste@teste.com",
+            Regime = new RegimeTributario
+            {
+                OptanteSimplesNacional = OptanteSimplesNacional.NaoOptante,
+                RegimeEspecial = RegimeEspecial.Nenhum
+            }
+        };
+
+        var toma = SetupOpenNFSeNacional.ObterTomador("2");
+
+        var serv = new ServicoNFSe
+        {
+            Localidade = new LocalidadeNFSe
+            {
+                // Serviço prestado no município do provedor Fiorilli.
+                CodMunicipioPrestacao = SetupOpenNFSeNacional.CodMunIBGE
+            },
+            Informacoes = new InformacoesServico
+            {
+                CodTributacaoNacional = "070201",
+                //CodTributacaoMunicipio = "0000070200001",
+                Descricao = "Referente ao servico prestado de Desenvolvimento"
+            },
+            Obra = new ObraNFSe()
+            {
+                Endereco = new EnderecoSimplesNFSe()
+                {
+                    CEP = "17250000",
+                    Logradouro = "ESTRADA MUNICIPAL ENTRE BARIRI x ITAJU",
+                    Numero = "s/n",
+                    Bairro = "ESTRADA"
+                }
+            }
+        };
+
+        var valores = new ValoresDps
+        {
+            ValoresServico = new ValoresServico
+            {
+                Valor = 1
+            },
+            Tributos = new TributosNFSe
+            {
+                Municipal = new TributoMunicipal
+                {
+                    ISSQN = TributoISSQN.OperacaoTributavel,
+                    TipoRetencaoISSQN = TipoRetencaoISSQN.NaoRetido,
+                },
+                Total = new TotalTributos
+                {
+                    PorcentagemTotal = new PorcentagemTotalTributos
+                    {
+                        TotalEstadual = 0,
+                        TotalFederal = 0,
+                        TotalMunicipal = 0,
+                    }
+                }
+            }
+        };
+
+        var dps = new Dps
+        {
+            Versao = openNFSeNacional.Configuracoes.Geral.Versao,
+            Informacoes = new InfDps
+            {
+                Id = "DPS" + SetupOpenNFSeNacional.CodMunIBGE +
+                     SetupOpenNFSeNacional.TipoInscricaoFederal +
+                     SetupOpenNFSeNacional.InscricaoFederal.PadLeft(14, '0') +
+                     SetupOpenNFSeNacional.SerieDPS.PadLeft(5, '0') +
+                     SetupOpenNFSeNacional.NumDPS.PadLeft(15, '0'),
+                TipoAmbiente = DFe.Core.Common.DFeTipoAmbiente.Homologacao,
+                DhEmissao = DateTime.Now,
+                LocalidadeEmitente = SetupOpenNFSeNacional.CodMunIBGE,
+                Serie = SetupOpenNFSeNacional.SerieDPS,
+                NumeroDps = SetupOpenNFSeNacional.NumDPS,
+                Competencia = DateTime.Now,
+                TipoEmitente = EmitenteDps.Prestador,
+                Prestador = prest,
+                Tomador = toma,
+                Servico = serv,
+                Valores = valores,
+                IBSCBS = null,
+            }
+        };
+
+        var retorno = await openNFSeNacional.EnviarAsync(dps);
+
+        Assert.IsTrue(retorno.Sucesso);
+    }
+
+    /// <summary>
+    /// Emissão simples sem tomador (operação recepcionarDps).
+    /// </summary>
+    [TestMethod]
+    public async Task EmissaoNFSeFiorilliSemTomador()
+    {
+        var openNFSeNacional = new OpenNFSeNacional();
+        SetupOpenNFSeNacional.ConfigurarFiorilli(openNFSeNacional, "2", "1", "1");
+
+        var prest = new PrestadorDps
+        {
+            CNPJ = SetupOpenNFSeNacional.InscricaoFederal,
+            InscricaoMunicipal = SetupOpenNFSeNacional.InscricaoMunicipal,
+            Email = "teste@teste.com",
+            Regime = new RegimeTributario
+            {
+                OptanteSimplesNacional = OptanteSimplesNacional.NaoOptante,
+                RegimeEspecial = RegimeEspecial.Nenhum
+            }
+        };
+
+        var serv = new ServicoNFSe
+        {
+            Localidade = new LocalidadeNFSe
+            {
+                CodMunicipioPrestacao = SetupOpenNFSeNacional.CodMunIBGE
+            },
+            Informacoes = new InformacoesServico
+            {
+                CodTributacaoNacional = "010101",
+                //CodTributacaoMunicipio = "002",
+                Descricao = "Servico sem tomador - emissao simples"
+            }
+        };
+
+        var valores = new ValoresDps
+        {
+            ValoresServico = new ValoresServico
+            {
+                Valor = 100
+            },
+            Tributos = new TributosNFSe
+            {
+                Municipal = new TributoMunicipal
+                {
+                    ISSQN = TributoISSQN.OperacaoTributavel,
+                    TipoRetencaoISSQN = TipoRetencaoISSQN.NaoRetido,
+                },
+                Total = new TotalTributos
+                {
+                    PorcentagemTotal = new PorcentagemTotalTributos
+                    {
+                        TotalEstadual = 0,
+                        TotalFederal = 0,
+                        TotalMunicipal = 0,
+                    }
+                }
+            }
+        };
+
+        var dps = new Dps
+        {
+            Versao = openNFSeNacional.Configuracoes.Geral.Versao,
+            Informacoes = new InfDps
+            {
+                Id = "DPS" + SetupOpenNFSeNacional.CodMunIBGE +
+                     SetupOpenNFSeNacional.TipoInscricaoFederal +
+                     SetupOpenNFSeNacional.InscricaoFederal.PadLeft(14, '0') +
+                     SetupOpenNFSeNacional.SerieDPS.PadLeft(5, '0') +
+                     SetupOpenNFSeNacional.NumDPS.PadLeft(15, '0'),
+                TipoAmbiente = DFe.Core.Common.DFeTipoAmbiente.Homologacao,
+                DhEmissao = DateTime.Now,
+                LocalidadeEmitente = SetupOpenNFSeNacional.CodMunIBGE,
+                Serie = SetupOpenNFSeNacional.SerieDPS,
+                NumeroDps = SetupOpenNFSeNacional.NumDPS,
+                Competencia = DateTime.Now,
+                TipoEmitente = EmitenteDps.Prestador,
+                Prestador = prest,
+                Tomador = null,
+                Servico = serv,
+                Valores = valores,
+                IBSCBS = null,
+            }
+        };
+
+        var retorno = await openNFSeNacional.EnviarAsync(dps);
+
+        Assert.IsTrue(retorno.Sucesso);
+    }
+    
+    [TestMethod]
+    public async Task CancelamentoNFSeFiorilli()
+    {
+        var openNFSeNacional = new OpenNFSeNacional();
+        SetupOpenNFSeNacional.ConfigurarFiorilli(openNFSeNacional);
+
+        var chaveNFse = "35052031206345083000137000000000000326070068624920";
+
+        var cancelamento = new EventoCancelamento
+        {
+            CodMotivo = MotivoCancelamento.ErroEmissao,
+            Motivo = "Dados inválidos"
+        };
+
+        var evento = new PedidoRegistroEvento();
+        evento.Versao = openNFSeNacional.Configuracoes.Geral.Versao;
+        evento.Informacoes = new()
+        {
+            Id = "PRE" + chaveNFse + TipoEventoCod.Cancelamento,
+            ChNFSe = chaveNFse,
+            CNPJAutor = SetupOpenNFSeNacional.InscricaoFederal,
+            DhEvento = DateTime.Now,
+            TipoAmbiente = DFe.Core.Common.DFeTipoAmbiente.Homologacao,
+            Evento = cancelamento
+        };
+
+        var retorno = await openNFSeNacional.EnviarEventoAsync(evento);
+
+        Assert.IsTrue(retorno.Sucesso);
+    }
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/ConsultaLoteFiltro.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/ConsultaLoteFiltro.cs
@@ -1,0 +1,31 @@
+namespace OpenAC.Net.NFSe.Nacional.Common.Model;
+
+/// <summary>
+/// Filtro para consulta de lote de DPS (operação <c>consultarLoteDps</c> do provedor Fiorilli).
+/// </summary>
+public sealed class ConsultaLoteFiltro
+{
+    #region Properties
+
+    /// <summary>
+    /// Protocolo retornado no envio assíncrono do lote.
+    /// </summary>
+    public string Protocolo { get; set; } = string.Empty;
+
+    /// <summary>
+    /// CNPJ do transmissor do lote.
+    /// </summary>
+    public string? CNPJ { get; set; }
+
+    /// <summary>
+    /// CPF do transmissor do lote.
+    /// </summary>
+    public string? CPF { get; set; }
+
+    /// <summary>
+    /// Inscrição municipal do transmissor do lote.
+    /// </summary>
+    public string? IM { get; set; }
+
+    #endregion Properties
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/ConsultaNFSeFiltro.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/ConsultaNFSeFiltro.cs
@@ -1,0 +1,48 @@
+namespace OpenAC.Net.NFSe.Nacional.Common.Model;
+
+/// <summary>
+/// Filtro para consulta de NFS-e (operação <c>consultarNfse</c> do provedor Fiorilli).
+/// Informe ao menos um critério de identificação (chave, Id do DPS ou número/série do DPS)
+/// juntamente com a identificação do prestador quando aplicável.
+/// </summary>
+public sealed class ConsultaNFSeFiltro
+{
+    #region Properties
+
+    /// <summary>
+    /// CNPJ do prestador.
+    /// </summary>
+    public string? CNPJ { get; set; }
+
+    /// <summary>
+    /// CPF do prestador.
+    /// </summary>
+    public string? CPF { get; set; }
+
+    /// <summary>
+    /// Inscrição municipal do prestador.
+    /// </summary>
+    public string? IM { get; set; }
+
+    /// <summary>
+    /// Chave de acesso da NFS-e.
+    /// </summary>
+    public string? ChaveNFSe { get; set; }
+
+    /// <summary>
+    /// Identificador do DPS que gerou a NFS-e.
+    /// </summary>
+    public string? IdDPS { get; set; }
+
+    /// <summary>
+    /// Número do DPS.
+    /// </summary>
+    public string? NumeroDPS { get; set; }
+
+    /// <summary>
+    /// Série do DPS.
+    /// </summary>
+    public string? SerieDPS { get; set; }
+
+    #endregion Properties
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/EventoServicoNFSe.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/EventoServicoNFSe.cs
@@ -46,7 +46,7 @@ public sealed class EventoServicoNFSe
     /// <summary>
     /// Descrição do evento.
     /// </summary>
-    [DFeElement(TipoCampo.Str, "desc", Min = 1, Max = 255, Ocorrencia = Ocorrencia.Obrigatoria)]
+    [DFeElement(TipoCampo.Str, "xNome", Min = 1, Max = 255, Ocorrencia = Ocorrencia.Obrigatoria)]
     public string Descricao { get; set; } = string.Empty;
     
     /// <summary>
@@ -64,7 +64,7 @@ public sealed class EventoServicoNFSe
     /// <summary>
     /// Identificador do evento.
     /// </summary>
-    [DFeElement(TipoCampo.Str, "id", Min = 1, Max = 30, Ocorrencia = Ocorrencia.NaoObrigatoria)]
+    [DFeElement(TipoCampo.Str, "idAtvEvt", Min = 1, Max = 30, Ocorrencia = Ocorrencia.NaoObrigatoria)]
     public string IdEvento { get; set; } = string.Empty;
 
     /// <summary>

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/LoteDps.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/LoteDps.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace OpenAC.Net.NFSe.Nacional.Common.Model;
+
+/// <summary>
+/// Representa um lote de DPS a ser transmitido para provedores que suportam envio em lote
+/// (ex.: Fiorilli - operações <c>recepcionarLoteDps</c> e <c>recepcionarLoteDpsSincrono</c>).
+/// </summary>
+public sealed class LoteDps
+{
+    #region Properties
+
+    /// <summary>
+    /// Identificador opcional do lote (atributo <c>Id</c> do elemento <c>LoteDps</c>).
+    /// </summary>
+    public string? Id { get; set; }
+
+    /// <summary>
+    /// Número do lote.
+    /// </summary>
+    public long NumeroLote { get; set; }
+
+    /// <summary>
+    /// CNPJ do transmissor do lote. Informar CNPJ ou CPF.
+    /// </summary>
+    public string? CNPJ { get; set; }
+
+    /// <summary>
+    /// CPF do transmissor do lote. Informar CNPJ ou CPF.
+    /// </summary>
+    public string? CPF { get; set; }
+
+    /// <summary>
+    /// Inscrição municipal do transmissor do lote.
+    /// </summary>
+    public string? IM { get; set; }
+
+    /// <summary>
+    /// Documentos DPS que compõem o lote.
+    /// </summary>
+    public List<Dps> Documentos { get; set; } = new();
+
+    /// <summary>
+    /// Quantidade de DPS no lote (derivado de <see cref="Documentos"/>).
+    /// </summary>
+    public int QuantidadeDps => Documentos.Count;
+
+    #endregion Properties
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/NFSeResponse.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/NFSeResponse.cs
@@ -69,6 +69,25 @@ public sealed class NFSeResponse<T> : IOpenLog where T : class, new()
         }
     }
 
+    /// <summary>
+    /// Inicializa uma nova instância da classe <see cref="NFSeResponse{T}"/> com o resultado já processado.
+    /// Utilizado por provedores que retornam XML/SOAP (ex.: Fiorilli), onde a resposta não é desserializada de JSON.
+    /// </summary>
+    /// <param name="xmlEnvio">XML enviado na requisição.</param>
+    /// <param name="envio">Conteúdo enviado (envelope/corpo da requisição).</param>
+    /// <param name="resposta">Resposta bruta recebida (envelope/corpo da resposta).</param>
+    /// <param name="sucesso">Indica se a operação foi bem-sucedida.</param>
+    /// <param name="resultado">Resultado já processado a partir da resposta.</param>
+    private NFSeResponse(string xmlEnvio, string envio, string resposta, bool sucesso, T? resultado)
+    {
+        XmlEnvio = xmlEnvio;
+        JsonEnvio = envio;
+        JsonRetorno = resposta;
+        Sucesso = sucesso;
+        JsonOptions = null;
+        Resultado = resultado;
+    }
+
     #endregion Constructors
 
     #region Properties
@@ -119,6 +138,21 @@ public sealed class NFSeResponse<T> : IOpenLog where T : class, new()
     public static NFSeResponse<T> Create(string xmlEnvio, string envio, string resposta, bool sucesso, JsonSerializerOptions? jsonOptions = null)
     {
         return new NFSeResponse<T>(xmlEnvio, envio, resposta, sucesso, jsonOptions);
+    }
+
+    /// <summary>
+    /// Cria uma instância de <see cref="NFSeResponse{T}"/> a partir de um resultado já processado.
+    /// Utilizado por provedores que retornam XML/SOAP (ex.: Fiorilli), evitando a desserialização de JSON.
+    /// </summary>
+    /// <param name="xmlEnvio">XML enviado na requisição.</param>
+    /// <param name="envio">Conteúdo enviado (envelope/corpo da requisição).</param>
+    /// <param name="resposta">Resposta bruta recebida (envelope/corpo da resposta).</param>
+    /// <param name="sucesso">Indica se a operação foi bem-sucedida.</param>
+    /// <param name="resultado">Resultado já processado a partir da resposta.</param>
+    /// <returns>Instância de <see cref="NFSeResponse{T}"/> com o resultado informado.</returns>
+    public static NFSeResponse<T> CreateComResultado(string xmlEnvio, string envio, string resposta, bool sucesso, T? resultado)
+    {
+        return new NFSeResponse<T>(xmlEnvio, envio, resposta, sucesso, resultado);
     }
 
     #endregion Methods

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaConsultaLote.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaConsultaLote.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace OpenAC.Net.NFSe.Nacional.Common.Model;
+
+/// <summary>
+/// Resposta da consulta de lote de DPS
+/// (operação <c>consultarLoteDps</c> do provedor Fiorilli).
+/// </summary>
+public sealed class RespostaConsultaLote : RespostaSoapBase
+{
+    /// <summary>
+    /// Situação do processamento do lote (campo <c>Situacao</c> do WSDL).
+    /// </summary>
+    public int Situacao { get; set; }
+
+    /// <summary>
+    /// NFS-e processadas no lote consultado.
+    /// </summary>
+    public List<NotaFiscalServico> NotasFiscais { get; set; } = new();
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaConsultaNFSe.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaConsultaNFSe.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace OpenAC.Net.NFSe.Nacional.Common.Model;
+
+/// <summary>
+/// Resposta da consulta de NFS-e
+/// (operação <c>consultarNfse</c> do provedor Fiorilli).
+/// </summary>
+public sealed class RespostaConsultaNFSe : RespostaSoapBase
+{
+    /// <summary>
+    /// NFS-e retornadas na consulta.
+    /// </summary>
+    public List<NotaFiscalServico> NotasFiscais { get; set; } = new();
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaRecepcaoLote.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaRecepcaoLote.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace OpenAC.Net.NFSe.Nacional.Common.Model;
+
+/// <summary>
+/// Resposta do envio de lote de DPS de forma assíncrona
+/// (operação <c>recepcionarLoteDps</c> do provedor Fiorilli).
+/// </summary>
+public class RespostaRecepcaoLote : RespostaSoapBase
+{
+    /// <summary>
+    /// Número do lote recebido.
+    /// </summary>
+    public long NumeroLote { get; set; }
+
+    /// <summary>
+    /// Data e hora do recebimento do lote.
+    /// </summary>
+    public DateTimeOffset DataRecebimento { get; set; }
+
+    /// <summary>
+    /// Protocolo gerado para acompanhamento do processamento do lote.
+    /// </summary>
+    public string Protocolo { get; set; } = string.Empty;
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaRecepcaoLoteSincrono.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaRecepcaoLoteSincrono.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace OpenAC.Net.NFSe.Nacional.Common.Model;
+
+/// <summary>
+/// Resposta do envio de lote de DPS de forma síncrona
+/// (operação <c>recepcionarLoteDpsSincrono</c> do provedor Fiorilli),
+/// contendo, além do protocolo, as NFS-e geradas.
+/// </summary>
+public sealed class RespostaRecepcaoLoteSincrono : RespostaRecepcaoLote
+{
+    /// <summary>
+    /// NFS-e geradas a partir do lote enviado.
+    /// </summary>
+    public List<NotaFiscalServico> NotasFiscais { get; set; } = new();
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaSoapBase.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/RespostaSoapBase.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace OpenAC.Net.NFSe.Nacional.Common.Model;
+
+/// <summary>
+/// Classe base para respostas de provedores baseados em SOAP/XML (ex.: Fiorilli).
+/// Diferente de <see cref="RespostaBase"/> (orientada a JSON), concentra as mensagens
+/// de processamento em uma única lista, refletindo o elemento <c>ListaMensagens</c> do WSDL.
+/// </summary>
+public abstract class RespostaSoapBase
+{
+    /// <summary>
+    /// Mensagens de processamento retornadas pelo provedor (alertas e/ou erros).
+    /// </summary>
+    public List<MensagemProcessamento> Mensagens { get; set; } = new();
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Common/NFSeWebserviceConfig.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/NFSeWebserviceConfig.cs
@@ -76,6 +76,12 @@ public sealed class NFSeWebserviceConfig : DFeWebserviceConfigBase
     }
 
     /// <summary>
+    /// Inscrição municipal do prestador. Exigida por provedores que a incluem no envelope de comunicação
+    /// (ex.: Fiorilli, na operação de cancelamento). Ignorada pelo provedor Nacional.
+    /// </summary>
+    public string? InscricaoMunicipal { get; set; }
+
+    /// <summary>
     /// Define se a aplicação deve validar o XML contra os schemas XSD antes do envio.
     /// </summary>
     public bool ValidarSchemas { get; set; }  = true;

--- a/src/OpenAC.Net.NFSe.Nacional/OpenNFSeNacional.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/OpenNFSeNacional.cs
@@ -237,5 +237,113 @@ public sealed class OpenNFSeNacional : IOpenLog
         }
     }
 
+    /// <summary>
+    /// Recepciona um lote de DPS de forma assíncrona, retornando o protocolo para acompanhamento.
+    /// </summary>
+    /// <param name="lote">Lote de DPS a ser enviado.</param>
+    /// <returns>Resposta contendo o protocolo do lote.</returns>
+    /// <remarks>Suportado apenas por provedores que expõem envio em lote (ex.: Fiorilli).</remarks>
+    public Task<NFSeResponse<RespostaRecepcaoLote>> EnviarLoteAsync(LoteDps lote)
+    {
+        var provider = NFSeServiceManager.Instance.GetProvider(Configuracoes);
+        var oldProtocol = ServicePointManager.SecurityProtocol;
+
+        try
+        {
+            ServicePointManager.SecurityProtocol = Configuracoes.WebServices.Protocolos;
+            return provider.EnviarLoteAsync(lote);
+        }
+        catch (Exception exception)
+        {
+            this.Log().Error("[EnviarLote]", exception);
+            throw;
+        }
+        finally
+        {
+            ServicePointManager.SecurityProtocol = oldProtocol;
+        }
+    }
+
+    /// <summary>
+    /// Recepciona um lote de DPS de forma síncrona, retornando as NFS-e geradas.
+    /// </summary>
+    /// <param name="lote">Lote de DPS a ser enviado.</param>
+    /// <returns>Resposta contendo o protocolo e as NFS-e geradas.</returns>
+    /// <remarks>Suportado apenas por provedores que expõem envio em lote síncrono (ex.: Fiorilli).</remarks>
+    public Task<NFSeResponse<RespostaRecepcaoLoteSincrono>> EnviarLoteSincronoAsync(LoteDps lote)
+    {
+        var provider = NFSeServiceManager.Instance.GetProvider(Configuracoes);
+        var oldProtocol = ServicePointManager.SecurityProtocol;
+
+        try
+        {
+            ServicePointManager.SecurityProtocol = Configuracoes.WebServices.Protocolos;
+            return provider.EnviarLoteSincronoAsync(lote);
+        }
+        catch (Exception exception)
+        {
+            this.Log().Error("[EnviarLoteSincrono]", exception);
+            throw;
+        }
+        finally
+        {
+            ServicePointManager.SecurityProtocol = oldProtocol;
+        }
+    }
+
+    /// <summary>
+    /// Consulta o processamento de um lote de DPS a partir do protocolo.
+    /// </summary>
+    /// <param name="filtro">Filtro com o protocolo e a identificação do transmissor.</param>
+    /// <returns>Resposta contendo a situação e as NFS-e do lote.</returns>
+    /// <remarks>Suportado apenas por provedores que expõem consulta de lote (ex.: Fiorilli).</remarks>
+    public Task<NFSeResponse<RespostaConsultaLote>> ConsultarLoteAsync(ConsultaLoteFiltro filtro)
+    {
+        var provider = NFSeServiceManager.Instance.GetProvider(Configuracoes);
+        var oldProtocol = ServicePointManager.SecurityProtocol;
+
+        try
+        {
+            ServicePointManager.SecurityProtocol = Configuracoes.WebServices.Protocolos;
+            return provider.ConsultarLoteAsync(filtro);
+        }
+        catch (Exception exception)
+        {
+            this.Log().Error("[ConsultarLote]", exception);
+            throw;
+        }
+        finally
+        {
+            ServicePointManager.SecurityProtocol = oldProtocol;
+        }
+    }
+
+    /// <summary>
+    /// Consulta NFS-e por chave, Id do DPS ou número/série do DPS.
+    /// </summary>
+    /// <param name="filtro">Filtro da consulta.</param>
+    /// <returns>Resposta contendo as NFS-e encontradas.</returns>
+    /// <remarks>Suportado apenas por provedores que expõem consulta de NFS-e (ex.: Fiorilli).</remarks>
+    public Task<NFSeResponse<RespostaConsultaNFSe>> ConsultarNFSeAsync(ConsultaNFSeFiltro filtro)
+    {
+        var provider = NFSeServiceManager.Instance.GetProvider(Configuracoes);
+        var oldProtocol = ServicePointManager.SecurityProtocol;
+
+        try
+        {
+            ServicePointManager.SecurityProtocol = Configuracoes.WebServices.Protocolos;
+            return provider.ConsultarNFSeAsync(filtro);
+        }
+        catch (Exception exception)
+        {
+            this.Log().Error("[ConsultarNFSe]", exception);
+            throw;
+        }
+        finally
+        {
+            ServicePointManager.SecurityProtocol = oldProtocol;
+        }
+    }
+
     #endregion Methods
 }

--- a/src/OpenAC.Net.NFSe.Nacional/Resources/Municipios.nfse
+++ b/src/OpenAC.Net.NFSe.Nacional/Resources/Municipios.nfse
@@ -88,5 +88,34 @@
 				</Ambiente>
 			</Ambientes>
 		</serviceInfo>
+		<serviceInfo Id="3505203">
+            <Tipo>Fiorilli</Tipo>
+            <Nome>Bariri</Nome>
+            <UF>SP</UF>
+            <Ambientes>
+                <Ambiente Tipo="2">
+                    <Enderecos>
+                        <Endereco Tipo="Enviar">http://fi1.fiorilli.com.br:5663/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="EnviarEvento">http://fi1.fiorilli.com.br:5663/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="ConsultarNsu">http://fi1.fiorilli.com.br:5663/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="ConsultarChave">http://fi1.fiorilli.com.br:5663/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="DownloadDanfse">http://fi1.fiorilli.com.br:5663/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="ConsultarChaveDps">http://fi1.fiorilli.com.br:5663/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="ConsultaExisteDps">http://fi1.fiorilli.com.br:5663/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                    </Enderecos>
+                </Ambiente>
+                <Ambiente Tipo="1">
+                    <Enderecos>
+                        <Endereco Tipo="Enviar">http://187.62.191.5:5661/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="EnviarEvento">http://187.62.191.5:5661/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="ConsultarNsu">http://187.62.191.5:5661/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="ConsultarChave">http://187.62.191.5:5661/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="DownloadDanfse">http://187.62.191.5:5661/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="ConsultarChaveDps">http://187.62.191.5:5661/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                        <Endereco Tipo="ConsultaExisteDps">http://187.62.191.5:5661/IssWeb-ejb/IssWebWSNacional/IssWebWSNacionalPortType?wsdl</Endereco>
+                    </Enderecos>
+                </Ambiente>
+            </Ambientes>
+        </serviceInfo>
 	</Services>
 </NFSeServices>

--- a/src/OpenAC.Net.NFSe.Nacional/Webservice/Fiorilli/FiorilliSoap.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Webservice/Fiorilli/FiorilliSoap.cs
@@ -1,0 +1,227 @@
+// ***********************************************************************
+// Assembly         : OpenAC.Net.NFSe.Nacional
+// Author           : OpenAC .Net
+// ***********************************************************************
+// <summary>
+// Utilitários para montagem e leitura dos envelopes SOAP do provedor Fiorilli.
+// </summary>
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using OpenAC.Net.Core.Extensions;
+using OpenAC.Net.NFSe.Nacional.Common.Model;
+
+namespace OpenAC.Net.NFSe.Nacional.Webservice.Fiorilli;
+
+/// <summary>
+/// Utilitários para montagem e leitura dos envelopes SOAP do provedor Fiorilli
+/// (serviço <c>IssWebWSNacional</c>).
+/// </summary>
+/// <remarks>
+/// Os documentos assinados (DPS, pedRegEvento e NFS-e) são injetados/lidos de forma literal para
+/// preservar a assinatura digital byte a byte. Por isso o envelope é montado por concatenação de
+/// strings (e não via <see cref="XDocument"/>), evitando qualquer recanonização do conteúdo assinado.
+/// <para/>
+/// NOTA sobre namespaces: os elementos "invólucro" (RecepcionarDpsEnvio, LoteDps, IM, Protocolo, etc.)
+/// ficam no namespace do provedor (<see cref="NsFiorilli"/>), enquanto os documentos DPS/pedRegEvento/NFS-e
+/// carregam o próprio namespace nacional (<see cref="NsSped"/>). Caso a Fiorilli rejeite o documento por
+/// namespace/schema em homologação, este é o primeiro ponto a ajustar.
+/// </remarks>
+internal static class FiorilliSoap
+{
+    #region Constants
+
+    /// <summary>Namespace do envelope SOAP 1.1.</summary>
+    public const string NsSoapEnv = "http://schemas.xmlsoap.org/soap/envelope/";
+
+    /// <summary>Namespace do provedor Fiorilli (invólucros das operações).</summary>
+    public const string NsFiorilli = "http://www.fiorilli.com.br/nfse-nacional";
+
+    /// <summary>Namespace do padrão nacional (documentos DPS/NFS-e/eventos).</summary>
+    public const string NsSped = "http://www.sped.fazenda.gov.br/nfse";
+
+    #endregion Constants
+
+    #region Build
+
+    /// <summary>
+    /// Monta o envelope SOAP 1.1 ao redor do corpo informado.
+    /// </summary>
+    /// <param name="corpo">Conteúdo já serializado do corpo (Body) da requisição.</param>
+    /// <returns>Envelope SOAP completo.</returns>
+    public static string Envelope(string corpo) =>
+        $"<soapenv:Envelope xmlns:soapenv=\"{NsSoapEnv}\">" +
+        "<soapenv:Header/>" +
+        $"<soapenv:Body>{corpo}</soapenv:Body>" +
+        "</soapenv:Envelope>";
+
+    /// <summary>
+    /// Remove a declaração XML (<c>&lt;?xml ... ?&gt;</c>) e a BOM de um documento, permitindo
+    /// que ele seja embutido dentro de outro XML.
+    /// </summary>
+    /// <param name="xml">Documento XML.</param>
+    /// <returns>Documento sem o prólogo.</returns>
+    public static string RemoverProlog(string xml)
+    {
+        if (xml.IsEmpty()) return string.Empty;
+
+        var conteudo = xml.TrimStart('﻿', ' ', '\r', '\n', '\t');
+        if (!conteudo.StartsWith("<?xml", StringComparison.OrdinalIgnoreCase)) return conteudo;
+
+        var fim = conteudo.IndexOf("?>", StringComparison.Ordinal);
+        return fim < 0 ? conteudo : conteudo.Substring(fim + 2).TrimStart();
+    }
+
+    /// <summary>
+    /// Escapa um valor para uso como texto de um elemento XML.
+    /// </summary>
+    /// <param name="valor">Valor a ser escapado.</param>
+    /// <returns>Valor escapado (string vazia quando nulo).</returns>
+    public static string Escape(string? valor)
+    {
+        if (string.IsNullOrEmpty(valor)) return string.Empty;
+
+        return valor!
+            .Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("\"", "&quot;")
+            .Replace("'", "&apos;");
+    }
+
+    /// <summary>
+    /// Gera um elemento XML simples quando o valor está preenchido; caso contrário retorna vazio.
+    /// </summary>
+    /// <param name="nome">Nome do elemento.</param>
+    /// <param name="valor">Valor do elemento.</param>
+    /// <returns>Elemento serializado ou string vazia.</returns>
+    public static string Elemento(string nome, string? valor) =>
+        string.IsNullOrEmpty(valor) ? string.Empty : $"<{nome}>{Escape(valor)}</{nome}>";
+
+    #endregion Build
+
+    #region Parse
+
+    /// <summary>
+    /// Retorna o elemento invólucro da resposta (primeiro filho do Body do envelope).
+    /// </summary>
+    /// <param name="xml">Envelope SOAP de resposta.</param>
+    /// <returns>Elemento da resposta ou <c>null</c> quando não encontrado.</returns>
+    public static XElement? CorpoResposta(string xml)
+    {
+        if (xml.IsEmpty()) return null;
+
+        var doc = XDocument.Parse(xml);
+        var body = doc.Descendants().FirstOrDefault(x => x.Name.LocalName == "Body");
+        return body?.Elements().FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Verifica se o envelope contém um <c>soap:Fault</c> e extrai a mensagem correspondente.
+    /// </summary>
+    /// <param name="xml">Envelope SOAP de resposta.</param>
+    /// <param name="mensagem">Mensagem do fault, quando existente.</param>
+    /// <returns><c>true</c> se houver fault.</returns>
+    public static bool PossuiFault(string xml, out string mensagem)
+    {
+        mensagem = string.Empty;
+        if (xml.IsEmpty()) return false;
+
+        var doc = XDocument.Parse(xml);
+        var fault = doc.Descendants().FirstOrDefault(x => x.Name.LocalName == "Fault");
+        if (fault == null) return false;
+
+        mensagem = fault.Descendants().FirstOrDefault(x => x.Name.LocalName is "faultstring" or "Text")?.Value
+                   ?? fault.Value;
+        return true;
+    }
+
+    /// <summary>
+    /// Obtém o valor de um elemento filho direto do invólucro (busca por nome local).
+    /// </summary>
+    /// <param name="root">Elemento invólucro.</param>
+    /// <param name="nomeLocal">Nome local do elemento.</param>
+    /// <returns>Valor do elemento ou <c>null</c>.</returns>
+    public static string? Valor(XElement? root, string nomeLocal) =>
+        root?.Elements().FirstOrDefault(x => x.Name.LocalName == nomeLocal)?.Value;
+
+    /// <summary>
+    /// Lê a lista de mensagens (<c>ListaMensagens/mensagem</c>) presente na resposta.
+    /// </summary>
+    /// <param name="root">Elemento invólucro da resposta.</param>
+    /// <returns>Lista de mensagens de processamento.</returns>
+    public static List<MensagemProcessamento> Mensagens(XElement? root)
+    {
+        var resultado = new List<MensagemProcessamento>();
+        if (root == null) return resultado;
+
+        foreach (var msg in root.Descendants().Where(x => x.Name.LocalName == "mensagem"))
+        {
+            resultado.Add(new MensagemProcessamento
+            {
+                Codigo = msg.Elements().FirstOrDefault(x => x.Name.LocalName == "Codigo")?.Value ?? string.Empty,
+                Mensagem = msg.Elements().FirstOrDefault(x => x.Name.LocalName == "Mensagem")?.Value ?? string.Empty,
+                Complemento = msg.Elements().FirstOrDefault(x => x.Name.LocalName == "Correcao")?.Value ?? string.Empty,
+                Descricao = msg.Elements().FirstOrDefault(x => x.Name.LocalName == "IdDPS")?.Value ?? string.Empty
+            });
+        }
+
+        return resultado;
+    }
+
+    /// <summary>
+    /// Extrai os elementos <c>NFSe</c> da resposta e os carrega como <see cref="NotaFiscalServico"/>.
+    /// </summary>
+    /// <param name="root">Elemento invólucro da resposta.</param>
+    /// <returns>Lista de NFS-e.</returns>
+    public static List<NotaFiscalServico> Notas(XElement? root)
+    {
+        var resultado = new List<NotaFiscalServico>();
+        if (root == null) return resultado;
+
+        foreach (var nfse in root.Descendants().Where(x => x.Name.LocalName == "NFSe"))
+        {
+            var xml = nfse.ToString(SaveOptions.DisableFormatting);
+            var nota = NotaFiscalServico.Load(xml);
+            if (nota != null) resultado.Add(nota);
+        }
+
+        return resultado;
+    }
+
+    /// <summary>
+    /// Retorna o XML (sem formatação) do primeiro elemento <c>NFSe</c> encontrado na resposta.
+    /// </summary>
+    /// <param name="root">Elemento invólucro da resposta.</param>
+    /// <returns>XML da NFS-e ou string vazia.</returns>
+    public static string NotaXml(XElement? root)
+    {
+        var nfse = root?.Descendants().FirstOrDefault(x => x.Name.LocalName == "NFSe");
+        return nfse?.ToString(SaveOptions.DisableFormatting) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Tenta extrair a chave de acesso (50 dígitos) do atributo <c>Id</c> do elemento <c>infNFSe</c>.
+    /// </summary>
+    /// <param name="notaXml">XML da NFS-e.</param>
+    /// <returns>Chave de acesso ou string vazia.</returns>
+    public static string ChaveDaNota(string notaXml)
+    {
+        if (notaXml.IsEmpty()) return string.Empty;
+
+        var inf = XDocument.Parse(notaXml).Descendants().FirstOrDefault(x => x.Name.LocalName == "infNFSe");
+        var id = inf?.Attribute("Id")?.Value ?? string.Empty;
+
+        // O Id costuma ter o formato "NFS" + chave(50).
+        if (id.StartsWith("NFS", StringComparison.OrdinalIgnoreCase) && id.Length >= 53)
+            return id.Substring(3);
+
+        return id.Length == 50 ? id : string.Empty;
+    }
+
+    #endregion Parse
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Webservice/Fiorilli/FiorilliSoap.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Webservice/Fiorilli/FiorilliSoap.cs
@@ -10,7 +10,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
 using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using OpenAC.Net.Core.Extensions;
 using OpenAC.Net.NFSe.Nacional.Common.Model;
@@ -28,8 +31,10 @@ namespace OpenAC.Net.NFSe.Nacional.Webservice.Fiorilli;
 /// <para/>
 /// NOTA sobre namespaces: os elementos "invólucro" (RecepcionarDpsEnvio, LoteDps, IM, Protocolo, etc.)
 /// ficam no namespace do provedor (<see cref="NsFiorilli"/>), enquanto os documentos DPS/pedRegEvento/NFS-e
-/// carregam o próprio namespace nacional (<see cref="NsSped"/>). Caso a Fiorilli rejeite o documento por
-/// namespace/schema em homologação, este é o primeiro ponto a ajustar.
+/// carregam o próprio namespace nacional (<see cref="NsSped"/>). Documentos assinados com canonicalização
+/// inclusiva, como a DPS, são protegidos de namespaces ancestrais pelo formato de <see cref="Envelope"/>.
+/// O pedido de cancelamento possui ainda um perfil específico da Fiorilli, aplicado em
+/// <see cref="ReassinarEvento"/>.
 /// </remarks>
 internal static class FiorilliSoap
 {
@@ -53,11 +58,18 @@ internal static class FiorilliSoap
     /// </summary>
     /// <param name="corpo">Conteúdo já serializado do corpo (Body) da requisição.</param>
     /// <returns>Envelope SOAP completo.</returns>
+    /// <remarks>
+    /// O namespace do SOAP é declarado como PADRÃO (sem prefixo) de propósito. Os documentos assinados
+    /// como a DPS usam assinatura com canonicalização inclusiva; um prefixo declarado em ancestral
+    /// (ex.: <c>soapenv</c>) entraria no escopo do elemento assinado e seria incorporado à sua forma
+    /// canônica. Como o namespace padrão é sempre redeclarado/sombreado nos níveis abaixo (Fiorilli,
+    /// depois SPED), nada vaza para o conteúdo assinado. Não troque para um prefixo aqui.
+    /// </remarks>
     public static string Envelope(string corpo) =>
-        $"<soapenv:Envelope xmlns:soapenv=\"{NsSoapEnv}\">" +
-        "<soapenv:Header/>" +
-        $"<soapenv:Body>{corpo}</soapenv:Body>" +
-        "</soapenv:Envelope>";
+        $"<Envelope xmlns=\"{NsSoapEnv}\">" +
+        "<Header/>" +
+        $"<Body>{corpo}</Body>" +
+        "</Envelope>";
 
     /// <summary>
     /// Remove a declaração XML (<c>&lt;?xml ... ?&gt;</c>) e a BOM de um documento, permitindo
@@ -70,10 +82,100 @@ internal static class FiorilliSoap
         if (xml.IsEmpty()) return string.Empty;
 
         var conteudo = xml.TrimStart('﻿', ' ', '\r', '\n', '\t');
-        if (!conteudo.StartsWith("<?xml", StringComparison.OrdinalIgnoreCase)) return conteudo;
+        if (!conteudo.StartsWith("<?xml", StringComparison.OrdinalIgnoreCase)) return conteudo.TrimEnd();
 
         var fim = conteudo.IndexOf("?>", StringComparison.Ordinal);
-        return fim < 0 ? conteudo : conteudo.Substring(fim + 2).TrimStart();
+        return (fim < 0 ? conteudo : conteudo.Substring(fim + 2).TrimStart()).TrimEnd();
+    }
+
+    /// <summary>
+    /// Garante que o namespace do padrão nacional esteja declarado diretamente no elemento assinado.
+    /// </summary>
+    /// <param name="xml">Documento nacional já assinado.</param>
+    /// <param name="elementoAssinado">Nome local do elemento referenciado pela assinatura.</param>
+    /// <returns>Documento sem prólogo e com o namespace explícito no elemento assinado.</returns>
+    /// <remarks>
+    /// O namespace já é herdado normalmente do elemento raiz, mas o validador da Fiorilli exige a
+    /// declaração também na própria tag assinada. A inserção é textual para não reserializar o XML.
+    /// Como a ligação de namespace efetiva não muda, o digest calculado antes da inserção permanece válido.
+    /// </remarks>
+    public static string GarantirNamespaceExplicito(string xml, string elementoAssinado)
+    {
+        var conteudo = RemoverProlog(xml);
+        if (conteudo.IsEmpty() || elementoAssinado.IsEmpty()) return conteudo;
+
+        var inicioTag = conteudo.IndexOf($"<{elementoAssinado}", StringComparison.Ordinal);
+        if (inicioTag < 0) return conteudo;
+
+        var fimNome = inicioTag + elementoAssinado.Length + 1;
+        if (fimNome >= conteudo.Length || conteudo[fimNome] is not (' ' or '\t' or '\r' or '\n' or '>'))
+            return conteudo;
+
+        var fimTag = conteudo.IndexOf('>', fimNome);
+        if (fimTag < 0) return conteudo;
+
+        var tagInicial = conteudo.Substring(inicioTag, fimTag - inicioTag);
+        if (tagInicial.IndexOf("xmlns=", StringComparison.Ordinal) >= 0 ||
+            tagInicial.IndexOf("xmlns:", StringComparison.Ordinal) >= 0)
+            return conteudo;
+
+        return conteudo.Insert(fimNome, $" xmlns=\"{NsSped}\"");
+    }
+
+    /// <summary>
+    /// Reassina o pedido de evento com o perfil exigido pelo cancelamento da Fiorilli.
+    /// </summary>
+    /// <param name="xml">Pedido de evento já serializado.</param>
+    /// <param name="certificado">Certificado com chave privada.</param>
+    /// <returns>Pedido de evento assinado em uma única linha.</returns>
+    /// <remarks>
+    /// Apesar de a API 1.01 usar C14N inclusiva nos demais documentos, o método
+    /// <c>cancelarNFSe</c> da Fiorilli 3.10.2 retornou E172 com C14N inclusiva e aceitou
+    /// C14N exclusiva, RSA-SHA1 e SHA1 em uma chamada real ao provedor.
+    /// </remarks>
+    public static string ReassinarEvento(string xml, X509Certificate2 certificado)
+    {
+        var conteudo = GarantirNamespaceExplicito(xml, "infPedReg");
+        var documento = new XmlDocument { PreserveWhitespace = true };
+        documento.LoadXml(conteudo);
+
+        var assinaturaAnterior = documento
+            .GetElementsByTagName("Signature", SignedXml.XmlDsigNamespaceUrl)
+            .OfType<XmlElement>()
+            .SingleOrDefault();
+        assinaturaAnterior?.ParentNode?.RemoveChild(assinaturaAnterior);
+
+        var informacoes = documento
+            .GetElementsByTagName("infPedReg", NsSped)
+            .OfType<XmlElement>()
+            .Single();
+        var id = informacoes.GetAttribute("Id");
+        if (id.IsEmpty()) throw new InvalidOperationException("O elemento infPedReg não possui o atributo Id.");
+
+        using var chavePrivada = certificado.GetRSAPrivateKey()
+            ?? throw new InvalidOperationException("O certificado não possui uma chave privada RSA.");
+        var signedXml = new SignedXml(documento)
+        {
+            SigningKey = chavePrivada,
+            KeyInfo = new KeyInfo()
+        };
+        signedXml.KeyInfo.AddClause(new KeyInfoX509Data(certificado));
+        signedXml.SignedInfo!.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
+        signedXml.SignedInfo.SignatureMethod = SignedXml.XmlDsigRSASHA1Url;
+
+        var referencia = new Reference
+        {
+            Uri = $"#{id}",
+            DigestMethod = SignedXml.XmlDsigSHA1Url
+        };
+        referencia.AddTransform(new XmlDsigEnvelopedSignatureTransform());
+        referencia.AddTransform(new XmlDsigExcC14NTransform());
+        signedXml.AddReference(referencia);
+        signedXml.ComputeSignature();
+
+        documento.DocumentElement!.AppendChild(
+            documento.ImportNode(signedXml.GetXml(), true));
+        return documento.OuterXml.TrimEnd();
     }
 
     /// <summary>
@@ -171,6 +273,37 @@ internal static class FiorilliSoap
         }
 
         return resultado;
+    }
+
+    /// <summary>
+    /// Indica se a mensagem representa um erro. Segue a convenção da Fiorilli/padrão nacional,
+    /// em que códigos iniciados por "E" são erros (ex.: E172) e por "A" são alertas.
+    /// </summary>
+    /// <param name="mensagem">Mensagem de processamento.</param>
+    /// <returns><c>true</c> quando a mensagem é um erro.</returns>
+    public static bool EhErro(MensagemProcessamento mensagem) =>
+        mensagem.Codigo.StartsWith("E", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Indica se a coleção contém ao menos uma mensagem de erro.
+    /// </summary>
+    /// <param name="mensagens">Mensagens de processamento.</param>
+    /// <returns><c>true</c> quando há pelo menos um erro.</returns>
+    public static bool TemErro(IEnumerable<MensagemProcessamento> mensagens) => mensagens.Any(EhErro);
+
+    /// <summary>
+    /// Distribui as mensagens entre <see cref="RespostaBase.Erros"/> e <see cref="RespostaBase.Alertas"/>
+    /// de acordo com o prefixo do código.
+    /// </summary>
+    /// <param name="resposta">Resposta a ser preenchida.</param>
+    /// <param name="mensagens">Mensagens de processamento.</param>
+    public static void DistribuirMensagens(RespostaBase resposta, IEnumerable<MensagemProcessamento> mensagens)
+    {
+        foreach (var mensagem in mensagens)
+        {
+            if (EhErro(mensagem)) resposta.Erros.Add(mensagem);
+            else resposta.Alertas.Add(mensagem);
+        }
     }
 
     /// <summary>

--- a/src/OpenAC.Net.NFSe.Nacional/Webservice/Fiorilli/FiorilliWebService.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Webservice/Fiorilli/FiorilliWebService.cs
@@ -1,0 +1,450 @@
+// ***********************************************************************
+// Assembly         : OpenAC.Net.NFSe.Nacional
+// Author           : OpenAC .Net
+// ***********************************************************************
+// <copyright file="FiorilliWebService.cs" company="OpenAC .Net">
+//		        		   The MIT License (MIT)
+//	     		    Copyright (c) 2014-2026 Grupo OpenAC.Net
+//
+//	 Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//	 The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//	 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+// </copyright>
+// <summary></summary>
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using OpenAC.Net.Core.Extensions;
+using OpenAC.Net.Core.Logging;
+using OpenAC.Net.NFSe.Nacional.Common;
+using OpenAC.Net.NFSe.Nacional.Common.Model;
+using OpenAC.Net.NFSe.Nacional.Common.Types;
+
+namespace OpenAC.Net.NFSe.Nacional.Webservice.Fiorilli;
+
+/// <summary>
+/// Comunicação com o webservice SOAP da Fiorilli (<c>IssWebWSNacional</c>) que adota o layout
+/// do padrão nacional (namespace <c>http://www.sped.fazenda.gov.br/nfse</c>).
+/// </summary>
+/// <remarks>
+/// Diferentemente do provedor Nacional (REST/JSON), a Fiorilli expõe operações SOAP document/literal.
+/// Os documentos (DPS, pedRegEvento e NFS-e) continuam sendo gerados/assinados pelos models comuns;
+/// apenas o transporte (envelope SOAP e leitura da resposta XML) é específico deste provedor.
+/// Operações que a Fiorilli não expõe (distribuição por NSU, download de DANFSe e consulta de eventos
+/// por chave) lançam <see cref="NotSupportedException"/>.
+/// </remarks>
+public class FiorilliWebService : NFSeWebserviceBase
+{
+    #region Constructors
+
+    /// <summary>
+    /// Inicializa uma nova instância da classe <see cref="FiorilliWebService"/>.
+    /// </summary>
+    /// <param name="configuracaoNFSe">Configuração da NFSe.</param>
+    /// <param name="serviceInfo">Informações do serviço.</param>
+    public FiorilliWebService(ConfiguracaoNFSe configuracaoNFSe, NFSeServiceInfo serviceInfo) :
+        base(configuracaoNFSe, serviceInfo)
+    {
+    }
+
+    #endregion Constructors
+
+    #region NFS-e
+
+    /// <summary>
+    /// Recepciona a DPS e gera a NFS-e de forma síncrona (operação <c>recepcionarDps</c>).
+    /// </summary>
+    /// <param name="dps">DPS a ser enviada.</param>
+    /// <returns>Resposta do envio da DPS.</returns>
+    public override async Task<NFSeResponse<RespostaEnvioDps>> EnviarAsync(Dps dps)
+    {
+        dps.Assinar(Configuracao);
+        ValidarSchema(SchemaNFSe.DPS, dps.Xml, dps.Versao);
+
+        var documento = dps.Informacoes.Prestador.CPF ?? dps.Informacoes.Prestador.CNPJ;
+        var prefixo = dps.Informacoes.NumeroDps.ZeroFill(6);
+
+        GravarDpsEmDisco(dps.Xml, $"{prefixo}_dps.xml", documento, dps.Informacoes.DhEmissao.DateTime);
+
+        var corpo = $"<RecepcionarDpsEnvio xmlns=\"{FiorilliSoap.NsFiorilli}\">" +
+                    FiorilliSoap.RemoverProlog(dps.Xml) +
+                    "</RecepcionarDpsEnvio>";
+        var envelope = FiorilliSoap.Envelope(corpo);
+
+        var (sucessoHttp, resposta) = await EnviarSoapAsync("recepcionarDPS", envelope, $"Enviar-{prefixo}", documento);
+
+        var raiz = FiorilliSoap.CorpoResposta(resposta);
+        var notaXml = FiorilliSoap.NotaXml(raiz);
+
+        var resultado = new RespostaEnvioDps
+        {
+            XmlNFSe = notaXml
+        };
+        var mensagens = FiorilliSoap.Mensagens(raiz);
+        resultado.Erros.AddRange(mensagens);
+
+        if (!notaXml.IsEmpty())
+        {
+            resultado.ChaveAcesso = FiorilliSoap.ChaveDaNota(notaXml);
+            resultado.IdDps = dps.Informacoes.Id;
+            GravarNFSeEmDisco(notaXml, $"{(Configuracao.Arquivos.PadronizarNomes ? resultado.ChaveAcesso : prefixo)}_nfse.xml",
+                documento, dps.Informacoes.DhEmissao.DateTime);
+        }
+
+        var sucesso = sucessoHttp && !notaXml.IsEmpty();
+        return NFSeResponse<RespostaEnvioDps>.CreateComResultado(dps.Xml, envelope, resposta, sucesso, resultado);
+    }
+
+    #endregion NFS-e
+
+    #region Lote
+
+    /// <summary>
+    /// Recepciona um lote de DPS de forma assíncrona (operação <c>recepcionarLoteDps</c>).
+    /// </summary>
+    /// <param name="lote">Lote de DPS a ser enviado.</param>
+    /// <returns>Resposta contendo o protocolo do lote.</returns>
+    public override async Task<NFSeResponse<RespostaRecepcaoLote>> EnviarLoteAsync(LoteDps lote)
+    {
+        var (envelope, documento) = MontarEnvelopeLote(lote, "RecepcionarLoteDpsEnvio");
+
+        var (sucessoHttp, resposta) = await EnviarSoapAsync("recepcionarLoteDps", envelope,
+            $"EnviarLote-{lote.NumeroLote}", documento);
+
+        var raiz = FiorilliSoap.CorpoResposta(resposta);
+        var resultado = new RespostaRecepcaoLote
+        {
+            Protocolo = FiorilliSoap.Valor(raiz, "Protocolo") ?? string.Empty,
+            Mensagens = FiorilliSoap.Mensagens(raiz)
+        };
+        PreencherLote(resultado, raiz);
+
+        var sucesso = sucessoHttp && !resultado.Protocolo.IsEmpty();
+        return NFSeResponse<RespostaRecepcaoLote>.CreateComResultado(string.Empty, envelope, resposta, sucesso, resultado);
+    }
+
+    /// <summary>
+    /// Recepciona um lote de DPS de forma síncrona (operação <c>recepcionarLoteDpsSincrono</c>).
+    /// </summary>
+    /// <param name="lote">Lote de DPS a ser enviado.</param>
+    /// <returns>Resposta contendo o protocolo e as NFS-e geradas.</returns>
+    public override async Task<NFSeResponse<RespostaRecepcaoLoteSincrono>> EnviarLoteSincronoAsync(LoteDps lote)
+    {
+        var (envelope, documento) = MontarEnvelopeLote(lote, "RecepcionarLoteDpsSincronoEnvio");
+
+        var (sucessoHttp, resposta) = await EnviarSoapAsync("recepcionarLoteDpsSincrono", envelope,
+            $"EnviarLoteSincrono-{lote.NumeroLote}", documento);
+
+        var raiz = FiorilliSoap.CorpoResposta(resposta);
+        var resultado = new RespostaRecepcaoLoteSincrono
+        {
+            Protocolo = FiorilliSoap.Valor(raiz, "Protocolo") ?? string.Empty,
+            NotasFiscais = FiorilliSoap.Notas(raiz),
+            Mensagens = FiorilliSoap.Mensagens(raiz)
+        };
+        PreencherLote(resultado, raiz);
+
+        var sucesso = sucessoHttp && (resultado.NotasFiscais.Count > 0 || !resultado.Protocolo.IsEmpty());
+        return NFSeResponse<RespostaRecepcaoLoteSincrono>.CreateComResultado(string.Empty, envelope, resposta, sucesso, resultado);
+    }
+
+    /// <summary>
+    /// Consulta o processamento de um lote de DPS pelo protocolo (operação <c>consultarLoteDps</c>).
+    /// </summary>
+    /// <param name="filtro">Filtro com o protocolo e a identificação do transmissor.</param>
+    /// <returns>Resposta contendo a situação e as NFS-e do lote.</returns>
+    public override async Task<NFSeResponse<RespostaConsultaLote>> ConsultarLoteAsync(ConsultaLoteFiltro filtro)
+    {
+        var documento = filtro.CNPJ ?? filtro.CPF;
+        var corpo = $"<ConsultarLoteDpsEnvio xmlns=\"{FiorilliSoap.NsFiorilli}\">" +
+                    FiorilliSoap.Elemento("CNPJ", filtro.CNPJ) +
+                    FiorilliSoap.Elemento("CPF", filtro.CPF) +
+                    FiorilliSoap.Elemento("IM", filtro.IM) +
+                    FiorilliSoap.Elemento("Protocolo", filtro.Protocolo) +
+                    "</ConsultarLoteDpsEnvio>";
+        var envelope = FiorilliSoap.Envelope(corpo);
+
+        var (sucessoHttp, resposta) = await EnviarSoapAsync("consultarLoteDps", envelope,
+            $"ConsultarLote-{filtro.Protocolo}", documento);
+
+        var raiz = FiorilliSoap.CorpoResposta(resposta);
+        var resultado = new RespostaConsultaLote
+        {
+            Situacao = int.TryParse(FiorilliSoap.Valor(raiz, "Situacao"), out var situacao) ? situacao : 0,
+            NotasFiscais = FiorilliSoap.Notas(raiz),
+            Mensagens = FiorilliSoap.Mensagens(raiz)
+        };
+
+        return NFSeResponse<RespostaConsultaLote>.CreateComResultado(string.Empty, envelope, resposta, sucessoHttp, resultado);
+    }
+
+    #endregion Lote
+
+    #region Consultas
+
+    /// <summary>
+    /// Consulta NFS-e por chave, Id do DPS ou número/série do DPS (operação <c>consultarNfse</c>).
+    /// </summary>
+    /// <param name="filtro">Filtro da consulta.</param>
+    /// <returns>Resposta contendo as NFS-e encontradas.</returns>
+    public override async Task<NFSeResponse<RespostaConsultaNFSe>> ConsultarNFSeAsync(ConsultaNFSeFiltro filtro)
+    {
+        var documento = filtro.CNPJ ?? filtro.CPF;
+        var corpo = $"<ConsultarNfseEnvio xmlns=\"{FiorilliSoap.NsFiorilli}\">" +
+                    FiorilliSoap.Elemento("CNPJ", filtro.CNPJ) +
+                    FiorilliSoap.Elemento("CPF", filtro.CPF) +
+                    FiorilliSoap.Elemento("IM", filtro.IM) +
+                    FiorilliSoap.Elemento("ChaveNFSe", filtro.ChaveNFSe) +
+                    FiorilliSoap.Elemento("IdDPS", filtro.IdDPS) +
+                    FiorilliSoap.Elemento("NumeroDPS", filtro.NumeroDPS) +
+                    FiorilliSoap.Elemento("SerieDPS", filtro.SerieDPS) +
+                    "</ConsultarNfseEnvio>";
+        var envelope = FiorilliSoap.Envelope(corpo);
+
+        var identificador = filtro.ChaveNFSe ?? filtro.IdDPS ?? filtro.NumeroDPS ?? "consulta";
+        var (sucessoHttp, resposta) = await EnviarSoapAsync("consultarNfse", envelope,
+            $"ConsultarNfse-{identificador}", documento);
+
+        var raiz = FiorilliSoap.CorpoResposta(resposta);
+        var resultado = new RespostaConsultaNFSe
+        {
+            NotasFiscais = FiorilliSoap.Notas(raiz),
+            Mensagens = FiorilliSoap.Mensagens(raiz)
+        };
+
+        return NFSeResponse<RespostaConsultaNFSe>.CreateComResultado(string.Empty, envelope, resposta, sucessoHttp, resultado);
+    }
+
+    /// <summary>
+    /// Retorna a chave de acesso da NFS-e a partir do identificador do DPS.
+    /// Implementado via <c>consultarNfse</c> (filtro por <c>IdDPS</c>).
+    /// </summary>
+    /// <param name="id">Identificação do DPS.</param>
+    /// <returns>Resposta da consulta contendo a chave de acesso.</returns>
+    public override async Task<NFSeResponse<RespostaConsultaChaveDps>> ConsultaChaveDpsAsync(string id)
+    {
+        var consulta = await ConsultarNFSeAsync(new ConsultaNFSeFiltro { IdDPS = id });
+        var notaXml = consulta.Resultado?.NotasFiscais.FirstOrDefault()?.Xml ?? string.Empty;
+
+        var resultado = new RespostaConsultaChaveDps
+        {
+            IdDps = id,
+            Chave = FiorilliSoap.ChaveDaNota(notaXml)
+        };
+        if (consulta.Resultado != null) resultado.Erros.AddRange(consulta.Resultado.Mensagens);
+
+        var sucesso = consulta.Sucesso && !resultado.Chave.IsEmpty();
+        return NFSeResponse<RespostaConsultaChaveDps>.CreateComResultado(string.Empty, consulta.JsonEnvio,
+            consulta.JsonRetorno, sucesso, resultado);
+    }
+
+    /// <summary>
+    /// Verifica se uma NFS-e foi emitida a partir do Id do DPS (via <c>consultarNfse</c>).
+    /// </summary>
+    /// <param name="id">Identificação do DPS.</param>
+    /// <returns>True se existir, caso contrário false.</returns>
+    public override async Task<bool> ConsultaExisteDpsAsync(string id)
+    {
+        var consulta = await ConsultarNFSeAsync(new ConsultaNFSeFiltro { IdDPS = id });
+        return consulta.Sucesso && (consulta.Resultado?.NotasFiscais.Count ?? 0) > 0;
+    }
+
+    #endregion Consultas
+
+    #region Eventos
+
+    /// <summary>
+    /// Recepciona o pedido de registro de evento (operação <c>cancelarNFSe</c> da Fiorilli).
+    /// </summary>
+    /// <param name="evento">Pedido de registro de evento (ex.: cancelamento).</param>
+    /// <returns>Resposta do envio do evento.</returns>
+    /// <remarks>
+    /// A Fiorilli expõe o registro de evento pela operação <c>cancelarNFSe</c>, que exige a inscrição
+    /// municipal do prestador no envelope. A inscrição é lida de
+    /// <see cref="Common.NFSeWebserviceConfig.InscricaoMunicipal"/>.
+    /// </remarks>
+    public override async Task<NFSeResponse<RespostaEnvioEvento>> EnviarEventoAsync(PedidoRegistroEvento evento)
+    {
+        var inscricaoMunicipal = Configuracao.WebServices.InscricaoMunicipal;
+        if (string.IsNullOrEmpty(inscricaoMunicipal))
+            throw new InvalidOperationException(
+                "Informe a inscrição municipal em Configuracoes.WebServices.InscricaoMunicipal para registrar eventos no provedor Fiorilli.");
+
+        evento.Assinar(Configuracao);
+        ValidarSchema(SchemaNFSe.Evento, evento.Xml, evento.Versao);
+
+        var documento = evento.Informacoes.CPFAutor ?? evento.Informacoes.CNPJAutor;
+
+        GravarDpsEmDisco(evento.Xml, $"{evento.Informacoes.ChNFSe}{evento.Informacoes.Evento}_evento.xml",
+            documento, evento.Informacoes.DhEvento.DateTime, true);
+
+        var corpo = $"<CancelarNFSeEnvio xmlns=\"{FiorilliSoap.NsFiorilli}\">" +
+                    FiorilliSoap.Elemento("IM", inscricaoMunicipal) +
+                    FiorilliSoap.RemoverProlog(evento.Xml) +
+                    "</CancelarNFSeEnvio>";
+        var envelope = FiorilliSoap.Envelope(corpo);
+
+        var (sucessoHttp, resposta) = await EnviarSoapAsync("cancelarNFSe", envelope,
+            $"Cancelar-{evento.Informacoes.ChNFSe}", documento);
+
+        var raiz = FiorilliSoap.CorpoResposta(resposta);
+        var resultado = new RespostaEnvioEvento
+        {
+            DataHoraProcessamento = ParseData(FiorilliSoap.Valor(raiz, "DataRecebimento"))
+        };
+        resultado.Erros.AddRange(FiorilliSoap.Mensagens(raiz));
+
+        var status = FiorilliSoap.Valor(raiz, "status");
+        if (!string.IsNullOrEmpty(status))
+            this.Log().Debug($"Fiorilli: [cancelarNFSe][Status] - {status}");
+
+        return NFSeResponse<RespostaEnvioEvento>.CreateComResultado(evento.Xml, envelope, resposta, sucessoHttp, resultado);
+    }
+
+    #endregion Eventos
+
+    #region Não suportadas
+
+    /// <summary>
+    /// Não suportado pela Fiorilli.
+    /// </summary>
+    public override Task<byte[]> DownloadDANFSeAsync(string chave) =>
+        throw OperacaoNaoSuportada(nameof(DownloadDANFSeAsync));
+
+    /// <summary>
+    /// Não suportado pela Fiorilli (não há distribuição por NSU no WSDL).
+    /// </summary>
+    public override Task<NFSeResponse<RespostaConsultaDFe>> ConsultaNsuAsync(int nsu) =>
+        throw OperacaoNaoSuportada(nameof(ConsultaNsuAsync));
+
+    /// <summary>
+    /// Não suportado pela Fiorilli (não há consulta de eventos por chave no WSDL).
+    /// </summary>
+    public override Task<NFSeResponse<RespostaConsultaDFe>> ConsultaChaveAsync(string chave) =>
+        throw OperacaoNaoSuportada(nameof(ConsultaChaveAsync));
+
+    #endregion Não suportadas
+
+    #region Helpers
+
+    /// <summary>
+    /// Monta o envelope de envio de lote (assíncrono ou síncrono) e retorna também o documento
+    /// do transmissor para fins de gravação em disco.
+    /// </summary>
+    /// <param name="lote">Lote de DPS.</param>
+    /// <param name="elementoEnvio">Nome do elemento invólucro da operação.</param>
+    /// <returns>Envelope SOAP e documento do transmissor.</returns>
+    private (string envelope, string? documento) MontarEnvelopeLote(LoteDps lote, string elementoEnvio)
+    {
+        var listaDps = new StringBuilder();
+        foreach (var dps in lote.Documentos)
+        {
+            dps.Assinar(Configuracao);
+            ValidarSchema(SchemaNFSe.DPS, dps.Xml, dps.Versao);
+            listaDps.Append(FiorilliSoap.RemoverProlog(dps.Xml));
+        }
+
+        var atributoId = string.IsNullOrEmpty(lote.Id) ? string.Empty : $" Id=\"{FiorilliSoap.Escape(lote.Id)}\"";
+
+        var corpo = $"<{elementoEnvio} xmlns=\"{FiorilliSoap.NsFiorilli}\">" +
+                    $"<LoteDps{atributoId}>" +
+                    FiorilliSoap.Elemento("NumeroLote", lote.NumeroLote.ToString(CultureInfo.InvariantCulture)) +
+                    FiorilliSoap.Elemento("CNPJ", lote.CNPJ) +
+                    FiorilliSoap.Elemento("CPF", lote.CPF) +
+                    FiorilliSoap.Elemento("IM", lote.IM) +
+                    FiorilliSoap.Elemento("QuantidadeDps", lote.QuantidadeDps.ToString(CultureInfo.InvariantCulture)) +
+                    $"<ListaDps>{listaDps}</ListaDps>" +
+                    "</LoteDps>" +
+                    $"</{elementoEnvio}>";
+
+        return (FiorilliSoap.Envelope(corpo), lote.CNPJ ?? lote.CPF);
+    }
+
+    /// <summary>
+    /// Preenche os campos comuns de resposta de lote (número do lote e data de recebimento).
+    /// </summary>
+    /// <param name="resposta">Resposta a ser preenchida.</param>
+    /// <param name="raiz">Elemento invólucro da resposta.</param>
+    private static void PreencherLote(RespostaRecepcaoLote resposta, XElement? raiz)
+    {
+        if (long.TryParse(FiorilliSoap.Valor(raiz, "NumeroLote"), out var numeroLote))
+            resposta.NumeroLote = numeroLote;
+
+        resposta.DataRecebimento = ParseData(FiorilliSoap.Valor(raiz, "DataRecebimento"));
+    }
+
+    /// <summary>
+    /// Converte um texto em <see cref="DateTimeOffset"/> (retorna default quando inválido).
+    /// </summary>
+    /// <param name="valor">Texto da data.</param>
+    /// <returns>Data convertida ou default.</returns>
+    private static DateTimeOffset ParseData(string? valor) =>
+        DateTimeOffset.TryParse(valor, CultureInfo.InvariantCulture, DateTimeStyles.None, out var data)
+            ? data
+            : default;
+
+    /// <summary>
+    /// Envia o envelope SOAP, grava requisição/resposta em disco e retorna o status e o corpo da resposta.
+    /// </summary>
+    /// <param name="soapAction">Valor do cabeçalho SOAPAction.</param>
+    /// <param name="envelope">Envelope SOAP.</param>
+    /// <param name="nomeArquivo">Prefixo do nome dos arquivos gravados em disco.</param>
+    /// <param name="documento">Documento do prestador/transmissor para composição do caminho.</param>
+    /// <returns>Indicador de sucesso HTTP (sem fault) e o corpo da resposta.</returns>
+    private async Task<(bool sucesso, string resposta)> EnviarSoapAsync(string soapAction, string envelope,
+        string nomeArquivo, string? documento)
+    {
+        this.Log().Debug($"Fiorilli: [{soapAction}][Envio] - {envelope}");
+        GravarArquivoEmDisco(envelope, $"{nomeArquivo}-env.xml", documento);
+
+        var url = ObterUrl();
+        var content = new StringContent(envelope, Encoding.UTF8, "text/xml");
+        var headers = new[] { new KeyValuePair<string, string>("SOAPAction", $"\"{soapAction}\"") };
+
+        var httpResponse = await SendAsync(content, HttpMethod.Post, url, headers);
+        var resposta = await httpResponse.Content.ReadAsStringAsync();
+
+        this.Log().Debug($"Fiorilli: [{soapAction}][Resposta] - {resposta}");
+        GravarArquivoEmDisco(resposta, $"{nomeArquivo}-resp.xml", documento);
+
+        var possuiFault = FiorilliSoap.PossuiFault(resposta, out var faultMsg);
+        if (possuiFault) this.Log().Debug($"Fiorilli: [{soapAction}][Fault] - {faultMsg}");
+
+        return (httpResponse.IsSuccessStatusCode && !possuiFault, resposta);
+    }
+
+    /// <summary>
+    /// Obtém o endpoint SOAP configurado para o ambiente atual.
+    /// </summary>
+    /// <returns>URL do webservice.</returns>
+    /// <exception cref="InvalidOperationException">Quando o endpoint não está configurado.</exception>
+    private string ObterUrl()
+    {
+        var ambiente = ServiceInfo[Configuracao.WebServices.Ambiente];
+        if (!ambiente.Enderecos.TryGetValue(TipoUrl.Enviar, out var url) || string.IsNullOrEmpty(url))
+            throw new InvalidOperationException("Endpoint SOAP do provedor Fiorilli não configurado (TipoUrl.Enviar).");
+
+        return url;
+    }
+
+    #endregion Helpers
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Webservice/Fiorilli/FiorilliWebService.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Webservice/Fiorilli/FiorilliWebService.cs
@@ -99,8 +99,7 @@ public class FiorilliWebService : NFSeWebserviceBase
         {
             XmlNFSe = notaXml
         };
-        var mensagens = FiorilliSoap.Mensagens(raiz);
-        resultado.Erros.AddRange(mensagens);
+        FiorilliSoap.DistribuirMensagens(resultado, FiorilliSoap.Mensagens(raiz));
 
         if (!notaXml.IsEmpty())
         {
@@ -110,7 +109,7 @@ public class FiorilliWebService : NFSeWebserviceBase
                 documento, dps.Informacoes.DhEmissao.DateTime);
         }
 
-        var sucesso = sucessoHttp && !notaXml.IsEmpty();
+        var sucesso = sucessoHttp && !notaXml.IsEmpty() && resultado.Erros.Count == 0;
         return NFSeResponse<RespostaEnvioDps>.CreateComResultado(dps.Xml, envelope, resposta, sucesso, resultado);
     }
 
@@ -138,7 +137,7 @@ public class FiorilliWebService : NFSeWebserviceBase
         };
         PreencherLote(resultado, raiz);
 
-        var sucesso = sucessoHttp && !resultado.Protocolo.IsEmpty();
+        var sucesso = sucessoHttp && !resultado.Protocolo.IsEmpty() && !FiorilliSoap.TemErro(resultado.Mensagens);
         return NFSeResponse<RespostaRecepcaoLote>.CreateComResultado(string.Empty, envelope, resposta, sucesso, resultado);
     }
 
@@ -163,7 +162,8 @@ public class FiorilliWebService : NFSeWebserviceBase
         };
         PreencherLote(resultado, raiz);
 
-        var sucesso = sucessoHttp && (resultado.NotasFiscais.Count > 0 || !resultado.Protocolo.IsEmpty());
+        var sucesso = sucessoHttp && (resultado.NotasFiscais.Count > 0 || !resultado.Protocolo.IsEmpty()) &&
+                      !FiorilliSoap.TemErro(resultado.Mensagens);
         return NFSeResponse<RespostaRecepcaoLoteSincrono>.CreateComResultado(string.Empty, envelope, resposta, sucesso, resultado);
     }
 
@@ -194,7 +194,8 @@ public class FiorilliWebService : NFSeWebserviceBase
             Mensagens = FiorilliSoap.Mensagens(raiz)
         };
 
-        return NFSeResponse<RespostaConsultaLote>.CreateComResultado(string.Empty, envelope, resposta, sucessoHttp, resultado);
+        var sucesso = sucessoHttp && !FiorilliSoap.TemErro(resultado.Mensagens);
+        return NFSeResponse<RespostaConsultaLote>.CreateComResultado(string.Empty, envelope, resposta, sucesso, resultado);
     }
 
     #endregion Lote
@@ -231,7 +232,8 @@ public class FiorilliWebService : NFSeWebserviceBase
             Mensagens = FiorilliSoap.Mensagens(raiz)
         };
 
-        return NFSeResponse<RespostaConsultaNFSe>.CreateComResultado(string.Empty, envelope, resposta, sucessoHttp, resultado);
+        var sucesso = sucessoHttp && !FiorilliSoap.TemErro(resultado.Mensagens);
+        return NFSeResponse<RespostaConsultaNFSe>.CreateComResultado(string.Empty, envelope, resposta, sucesso, resultado);
     }
 
     /// <summary>
@@ -250,7 +252,7 @@ public class FiorilliWebService : NFSeWebserviceBase
             IdDps = id,
             Chave = FiorilliSoap.ChaveDaNota(notaXml)
         };
-        if (consulta.Resultado != null) resultado.Erros.AddRange(consulta.Resultado.Mensagens);
+        if (consulta.Resultado != null) FiorilliSoap.DistribuirMensagens(resultado, consulta.Resultado.Mensagens);
 
         var sucesso = consulta.Sucesso && !resultado.Chave.IsEmpty();
         return NFSeResponse<RespostaConsultaChaveDps>.CreateComResultado(string.Empty, consulta.JsonEnvio,
@@ -290,16 +292,18 @@ public class FiorilliWebService : NFSeWebserviceBase
                 "Informe a inscrição municipal em Configuracoes.WebServices.InscricaoMunicipal para registrar eventos no provedor Fiorilli.");
 
         evento.Assinar(Configuracao);
-        ValidarSchema(SchemaNFSe.Evento, evento.Xml, evento.Versao);
-
         var documento = evento.Informacoes.CPFAutor ?? evento.Informacoes.CNPJAutor;
+        var eventoAssinado = FiorilliSoap.ReassinarEvento(
+            evento.Xml,
+            Configuracao.Certificados.ObterCertificado());
+        ValidarSchema(SchemaNFSe.Evento, eventoAssinado, evento.Versao);
 
-        GravarDpsEmDisco(evento.Xml, $"{evento.Informacoes.ChNFSe}{evento.Informacoes.Evento}_evento.xml",
+        GravarDpsEmDisco(eventoAssinado, $"{evento.Informacoes.ChNFSe}{evento.Informacoes.Evento}_evento.xml",
             documento, evento.Informacoes.DhEvento.DateTime, true);
 
         var corpo = $"<CancelarNFSeEnvio xmlns=\"{FiorilliSoap.NsFiorilli}\">" +
                     FiorilliSoap.Elemento("IM", inscricaoMunicipal) +
-                    FiorilliSoap.RemoverProlog(evento.Xml) +
+                    eventoAssinado +
                     "</CancelarNFSeEnvio>";
         var envelope = FiorilliSoap.Envelope(corpo);
 
@@ -311,13 +315,14 @@ public class FiorilliWebService : NFSeWebserviceBase
         {
             DataHoraProcessamento = ParseData(FiorilliSoap.Valor(raiz, "DataRecebimento"))
         };
-        resultado.Erros.AddRange(FiorilliSoap.Mensagens(raiz));
+        FiorilliSoap.DistribuirMensagens(resultado, FiorilliSoap.Mensagens(raiz));
 
         var status = FiorilliSoap.Valor(raiz, "status");
         if (!string.IsNullOrEmpty(status))
             this.Log().Debug($"Fiorilli: [cancelarNFSe][Status] - {status}");
 
-        return NFSeResponse<RespostaEnvioEvento>.CreateComResultado(evento.Xml, envelope, resposta, sucessoHttp, resultado);
+        var sucesso = sucessoHttp && resultado.Erros.Count == 0;
+        return NFSeResponse<RespostaEnvioEvento>.CreateComResultado(eventoAssinado, envelope, resposta, sucesso, resultado);
     }
 
     #endregion Eventos

--- a/src/OpenAC.Net.NFSe.Nacional/Webservice/NFSeServiceManager.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Webservice/NFSeServiceManager.cs
@@ -56,6 +56,13 @@ public sealed class NFSeServiceManager
                     { VersaoNFSe.Ve100, typeof(Tiplan.TiplanWebService) },
                     { VersaoNFSe.Ve101, typeof(Tiplan.TiplanWebService) }
                 }
+            },
+            {
+                NFSeProvider.Fiorilli, new Dictionary<VersaoNFSe, Type>
+                {
+                    { VersaoNFSe.Ve100, typeof(Fiorilli.FiorilliWebService) },
+                    { VersaoNFSe.Ve101, typeof(Fiorilli.FiorilliWebService) }
+                }
             }
         };
 

--- a/src/OpenAC.Net.NFSe.Nacional/Webservice/NFSeWebserviceBase.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Webservice/NFSeWebserviceBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -126,13 +127,59 @@ public abstract class NFSeWebserviceBase : IOpenLog
     public abstract Task<NFSeResponse<RespostaEnvioDps>> EnviarAsync(Dps dps);
 
     /// <summary>
+    /// Recepciona um lote de DPS de forma assíncrona, retornando o protocolo para acompanhamento.
+    /// </summary>
+    /// <param name="lote">Lote de DPS a ser enviado.</param>
+    /// <returns>Resposta contendo o protocolo do lote.</returns>
+    /// <remarks>Suportado apenas por provedores que expõem envio em lote (ex.: Fiorilli).</remarks>
+    public virtual Task<NFSeResponse<RespostaRecepcaoLote>> EnviarLoteAsync(LoteDps lote) =>
+        throw OperacaoNaoSuportada(nameof(EnviarLoteAsync));
+
+    /// <summary>
+    /// Recepciona um lote de DPS de forma síncrona, retornando as NFS-e geradas.
+    /// </summary>
+    /// <param name="lote">Lote de DPS a ser enviado.</param>
+    /// <returns>Resposta contendo o protocolo e as NFS-e geradas.</returns>
+    /// <remarks>Suportado apenas por provedores que expõem envio em lote síncrono (ex.: Fiorilli).</remarks>
+    public virtual Task<NFSeResponse<RespostaRecepcaoLoteSincrono>> EnviarLoteSincronoAsync(LoteDps lote) =>
+        throw OperacaoNaoSuportada(nameof(EnviarLoteSincronoAsync));
+
+    /// <summary>
+    /// Consulta o resultado do processamento de um lote de DPS a partir do protocolo.
+    /// </summary>
+    /// <param name="filtro">Filtro contendo o protocolo e a identificação do transmissor.</param>
+    /// <returns>Resposta contendo a situação e as NFS-e do lote.</returns>
+    /// <remarks>Suportado apenas por provedores que expõem consulta de lote (ex.: Fiorilli).</remarks>
+    public virtual Task<NFSeResponse<RespostaConsultaLote>> ConsultarLoteAsync(ConsultaLoteFiltro filtro) =>
+        throw OperacaoNaoSuportada(nameof(ConsultarLoteAsync));
+
+    /// <summary>
+    /// Consulta NFS-e por chave, Id do DPS ou número/série do DPS.
+    /// </summary>
+    /// <param name="filtro">Filtro da consulta.</param>
+    /// <returns>Resposta contendo as NFS-e encontradas.</returns>
+    /// <remarks>Suportado apenas por provedores que expõem consulta de NFS-e (ex.: Fiorilli).</remarks>
+    public virtual Task<NFSeResponse<RespostaConsultaNFSe>> ConsultarNFSeAsync(ConsultaNFSeFiltro filtro) =>
+        throw OperacaoNaoSuportada(nameof(ConsultarNFSeAsync));
+
+    /// <summary>
+    /// Cria a exceção padrão para operações não suportadas pelo provedor atual.
+    /// </summary>
+    /// <param name="operacao">Nome da operação não suportada.</param>
+    /// <returns>Instância de <see cref="NotSupportedException"/>.</returns>
+    protected NotSupportedException OperacaoNaoSuportada(string operacao) =>
+        new($"A operação '{operacao}' não é suportada pelo provedor '{ServiceInfo.Provider}'.");
+
+    /// <summary>
     /// Envia uma requisição HTTP para o webservice.
     /// </summary>
     /// <param name="content">Conteúdo da requisição.</param>
     /// <param name="method">Método HTTP.</param>
     /// <param name="url">URL do serviço.</param>
+    /// <param name="headers">Cabeçalhos adicionais a serem incluídos na requisição (ex.: SOAPAction).</param>
     /// <returns>Resposta HTTP.</returns>
-    protected virtual async Task<HttpResponseMessage> SendAsync(HttpContent? content, HttpMethod method, string url)
+    protected virtual async Task<HttpResponseMessage> SendAsync(HttpContent? content, HttpMethod method, string url,
+        IEnumerable<KeyValuePair<string, string>>? headers = null)
     {
         var handler = new HttpClientHandler();
 
@@ -149,6 +196,11 @@ public abstract class NFSeWebserviceBase : IOpenLog
 
         request.Headers.UserAgent.Add(productValue);
         request.Headers.UserAgent.Add(commentValue);
+
+        if (headers != null)
+            foreach (var header in headers)
+                request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
         request.Content = content;
 
         return await client.SendAsync(request);


### PR DESCRIPTION
## Correção das tags do `TCAtvEvento`

Atualiza o mapeamento XML em `EventoServicoNFSe`:

* `desc` → `xNome`
* `id` → `idAtvEvt`

Ajuste necessário para gerar e interpretar corretamente os eventos de serviço da NFS-e Nacional.
