### PR TITLE
Suporte ao CNPJ alfanumérico (layout v1.01)

### DIFF
--- a/src/OpenAC.Net.NFSe.Nacional.Test/TestSchemaV101.cs
+++ b/src/OpenAC.Net.NFSe.Nacional.Test/TestSchemaV101.cs
@@ -1,0 +1,238 @@
+using System.Text.RegularExpressions;
+using OpenAC.Net.DFe.Core;
+using OpenAC.Net.DFe.Core.Common;
+using OpenAC.Net.DFe.Core.Extensions;
+using OpenAC.Net.NFSe.Nacional.Common.Model;
+using OpenAC.Net.NFSe.Nacional.Common.Types;
+
+namespace OpenAC.Net.NFSe.Nacional.Test;
+
+/// <summary>
+/// Testes de conformidade com o schema v1.01 que rodam offline: não exigem <c>.env</c>,
+/// certificado digital nem acesso aos webservices.
+/// </summary>
+/// <remarks>
+/// <c>TCDPS</c> declara <c>ds:Signature</c> com <c>minOccurs="0"</c>, então uma DPS não assinada
+/// valida contra <c>DPS_v1.01.xsd</c>. Isso permite cobrir a serialização sem depender de
+/// infraestrutura externa.
+/// </remarks>
+[TestClass]
+public class TestSchemaV101
+{
+    /// <summary>CNPJ alfanumérico, formato admitido pelo TSCNPJ a partir do layout v1.01.</summary>
+    private const string CnpjAlfanumericoPrestador = "12ABC678000199";
+
+    private const string CnpjAlfanumericoTomador = "98XYZ432000188";
+
+    private const string CodMunicipio = "3550308";
+
+    /// <summary>Padrão <c>TSIdDPS</c> do <c>tiposSimples_v1.01.xsd</c>.</summary>
+    private static readonly Regex RegexIdDps =
+        new(@"^DPS[0-9]{7}(1[0-9]{14}|2[0-9A-Z]{14})[0-9]{20}$", RegexOptions.CultureInvariant);
+
+    private static string CaminhoSchemaDps =>
+        Path.Combine(AppContext.BaseDirectory, "Schemas", VersaoNFSe.Ve101.GetDFeValue(), "DPS_v1.01.xsd");
+
+    [TestMethod]
+    public void DpsComCnpjAlfanumerico_PreservaLetrasNoXml()
+    {
+        var dps = MontarDps();
+        dps.GerarId();
+
+        var xml = dps.GetXml(DFeSaveOptions.DisableFormatting);
+
+        StringAssert.Contains(xml, $"<CNPJ>{CnpjAlfanumericoPrestador}</CNPJ>",
+            "O CNPJ do prestador perdeu as letras na serialização.");
+        StringAssert.Contains(xml, $"<CNPJ>{CnpjAlfanumericoTomador}</CNPJ>",
+            "O CNPJ do tomador perdeu as letras na serialização.");
+    }
+
+    [TestMethod]
+    public void DpsComCnpjAlfanumerico_ValidaContraSchemaV101()
+    {
+        var dps = MontarDps();
+        dps.GerarId();
+
+        var xml = dps.GetXml(DFeSaveOptions.DisableFormatting);
+
+        Assert.IsTrue(File.Exists(CaminhoSchemaDps), $"Schema não encontrado em {CaminhoSchemaDps}.");
+
+        var valido = XmlSchemaValidation.ValidarXml(xml, CaminhoSchemaDps, out var erros, out _);
+
+        Assert.IsTrue(valido, "XML reprovado no schema v1.01:" + Environment.NewLine +
+                              string.Join(Environment.NewLine, erros));
+    }
+
+    [TestMethod]
+    public void DocDedRed_UsaNomesDeElementoDoTCDocDedRed()
+    {
+        var dps = MontarDps();
+        // TCInfoDedRed é um xs:choice: pDR, vDR ou documentos - preencher apenas um.
+        dps.Informacoes.Valores.ValoresDeducaoReducao = new ValoresDeducaoReducao
+        {
+            Documentos =
+            {
+                new DocumentoDeducaoReducao
+                {
+                    ChaveNFe = new string('1', 6) + CnpjAlfanumericoTomador + new string('2', 24),
+                    TipoDeducaoReducao = TipoDeducaoReducao.Materiais,
+                    DataEmissao = DateTime.Today,
+                    ValorDedutivelRedutivel = 10,
+                    ValorReducaoDeducao = 10
+                }
+            }
+        };
+        dps.GerarId();
+
+        var xml = dps.GetXml(DFeSaveOptions.DisableFormatting);
+
+        StringAssert.Contains(xml, "<chNFe>", "A chave da NF-e deve ser gravada em <chNFe>, não em <chNFSe>.");
+        StringAssert.Contains(xml, "<tpDedRed>", "O tipo de dedução/redução deve ser gravado em <tpDedRed>, não em <nDoc>.");
+
+        var valido = XmlSchemaValidation.ValidarXml(xml, CaminhoSchemaDps, out var erros, out _);
+
+        Assert.IsTrue(valido, "XML de dedução/redução reprovado no schema v1.01:" + Environment.NewLine +
+                              string.Join(Environment.NewLine, erros));
+    }
+
+    [TestMethod]
+    public void CnpjComFormatacao_EhNormalizadoParaAlfanumerico()
+    {
+        var pessoa = new InfoPessoaNFSe { CNPJ = "12.ABC.678/0001-99" };
+
+        Assert.AreEqual(CnpjAlfanumericoPrestador, pessoa.CNPJ);
+    }
+
+    [TestMethod]
+    public void GerarId_ComCnpj_MontaIdTipo2Com45Posicoes()
+    {
+        var dps = MontarDps();
+        dps.Informacoes.Serie = "13";
+        dps.Informacoes.NumeroDps = "7";
+
+        dps.GerarId();
+
+        var id = dps.Informacoes.Id;
+
+        Assert.AreEqual(45, id.Length, $"Id gerado com tamanho inválido: '{id}'.");
+        Assert.AreEqual("DPS", id.Substring(0, 3), "Literal inicial.");
+        Assert.AreEqual(CodMunicipio, id.Substring(3, 7), "Código do município.");
+        Assert.AreEqual("2", id.Substring(10, 1), "Tipo de inscrição federal (2 = CNPJ).");
+        Assert.AreEqual(CnpjAlfanumericoPrestador, id.Substring(11, 14), "Inscrição federal.");
+        Assert.AreEqual("00013", id.Substring(25, 5), "Série com 5 posições.");
+        Assert.AreEqual("000000000000007", id.Substring(30, 15), "Número da DPS com 15 posições.");
+        Assert.IsTrue(RegexIdDps.IsMatch(id), $"Id não casa com o padrão TSIdDPS: '{id}'.");
+    }
+
+    [TestMethod]
+    public void GerarId_ComCpf_MontaIdTipo1Com45Posicoes()
+    {
+        var dps = MontarDps();
+        dps.Informacoes.Prestador.CNPJ = null;
+        dps.Informacoes.Prestador.CPF = "12345678909";
+        dps.Informacoes.Serie = "1";
+        dps.Informacoes.NumeroDps = "1";
+
+        dps.GerarId();
+
+        var id = dps.Informacoes.Id;
+
+        Assert.AreEqual(45, id.Length, $"Id gerado com tamanho inválido: '{id}'.");
+        Assert.AreEqual("1", id.Substring(10, 1), "Tipo de inscrição federal (1 = CPF).");
+        Assert.AreEqual("00012345678909", id.Substring(11, 14), "CPF com 000 à esquerda.");
+        Assert.AreEqual("00001", id.Substring(25, 5), "Série com 5 posições.");
+        Assert.AreEqual("000000000000001", id.Substring(30, 15), "Número da DPS com 15 posições.");
+        Assert.IsTrue(RegexIdDps.IsMatch(id), $"Id não casa com o padrão TSIdDPS: '{id}'.");
+    }
+
+    [TestMethod]
+    public void GerarId_ComIdJaInformado_NaoSobrescreve()
+    {
+        var dps = MontarDps();
+        dps.Informacoes.Id = "DPS35503082" + CnpjAlfanumericoPrestador + "0001300000000000007";
+
+        var original = dps.Informacoes.Id;
+        dps.GerarId();
+
+        Assert.AreEqual(original, dps.Informacoes.Id);
+    }
+
+    /// <summary>
+    /// Monta uma DPS v1.01 mínima e completa o suficiente para passar no schema.
+    /// </summary>
+    private static Dps MontarDps() => new()
+    {
+        Versao = VersaoNFSe.Ve101,
+        Informacoes = new InfDps
+        {
+            TipoAmbiente = DFeTipoAmbiente.Homologacao,
+            DhEmissao = DateTime.Now,
+            LocalidadeEmitente = CodMunicipio,
+            Serie = "13",
+            NumeroDps = "7",
+            Competencia = DateTime.Now,
+            TipoEmitente = EmitenteDps.Prestador,
+            Prestador = new PrestadorDps
+            {
+                CNPJ = CnpjAlfanumericoPrestador,
+                Email = "prestador@teste.com",
+                Regime = new RegimeTributario
+                {
+                    OptanteSimplesNacional = OptanteSimplesNacional.NaoOptante,
+                    RegimeEspecial = RegimeEspecial.Nenhum
+                }
+            },
+            Tomador = new InfoPessoaNFSe
+            {
+                CNPJ = CnpjAlfanumericoTomador,
+                Nome = "Tomador de Teste Ltda",
+                Endereco = new EnderecoNFSe
+                {
+                    Logradouro = "Avenida Paulista",
+                    Numero = "1000",
+                    Bairro = "Bela Vista",
+                    Municipio = new MunicipioNacional
+                    {
+                        CEP = "01310100",
+                        CodMunicipio = CodMunicipio
+                    }
+                }
+            },
+            Servico = new ServicoNFSe
+            {
+                Localidade = new LocalidadeNFSe
+                {
+                    CodMunicipioPrestacao = CodMunicipio
+                },
+                Informacoes = new InformacoesServico
+                {
+                    CodTributacaoNacional = "010101",
+                    CodTributacaoMunicipio = "002",
+                    Descricao = "Servico de desenvolvimento de software"
+                }
+            },
+            Valores = new ValoresDps
+            {
+                ValoresServico = new ValoresServico { Valor = 100 },
+                Tributos = new TributosNFSe
+                {
+                    Municipal = new TributoMunicipal
+                    {
+                        ISSQN = TributoISSQN.OperacaoTributavel,
+                        TipoRetencaoISSQN = TipoRetencaoISSQN.NaoRetido
+                    },
+                    Total = new TotalTributos
+                    {
+                        PorcentagemTotal = new PorcentagemTotalTributos
+                        {
+                            TotalEstadual = 0,
+                            TotalFederal = 0,
+                            TotalMunicipal = 0
+                        }
+                    }
+                }
+            },
+            IBSCBS = null
+        }
+    };
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Common/DocumentoExtensions.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/DocumentoExtensions.cs
@@ -1,0 +1,73 @@
+// ***********************************************************************
+// Assembly         : OpenAC.Net.NFSe.Nacional
+// Author           : OpenAC .Net
+// ***********************************************************************
+// <copyright file="DocumentoExtensions.cs" company="OpenAC .Net">
+//		        		   The MIT License (MIT)
+//	     		    Copyright (c) 2014-2026 Grupo OpenAC.Net
+//
+//	 Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//	 The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//	 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+// </copyright>
+// <summary></summary>
+// ***********************************************************************
+
+using System.Text;
+
+namespace OpenAC.Net.NFSe.Nacional.Common;
+
+/// <summary>
+/// Normalização de documentos e chaves que admitem CNPJ alfanumérico.
+/// </summary>
+/// <remarks>
+/// A partir do layout v1.01 o CNPJ deixou de ser exclusivamente numérico (<c>TSCNPJ</c> passou de
+/// <c>[0-9]{14}</c> para <c>[0-9A-Z]{14}</c>), e o mesmo vale para as chaves e identificadores que o
+/// embutem (<c>TSChaveNFSe</c>, <c>TSChaveNFe</c>, <c>TSIdNumEvento</c>, …). Esses campos não podem
+/// mais ser serializados com <see cref="OpenAC.Net.DFe.Core.Serializer.TipoCampo.StrNumber"/>, que
+/// descarta as letras. A limpeza de formatação, que o <c>StrNumber</c> fazia implicitamente, passa a
+/// ser feita aqui preservando os caracteres alfanuméricos.
+/// </remarks>
+internal static class DocumentoExtensions
+{
+    #region Methods
+
+    /// <summary>
+    /// Remove qualquer caractere de formatação (pontos, barras, hífens, espaços) mantendo apenas
+    /// dígitos e letras, estas convertidas para maiúsculas.
+    /// </summary>
+    /// <param name="valor">Documento ou chave a normalizar.</param>
+    /// <returns>
+    /// O valor contendo apenas <c>[0-9A-Z]</c>, ou <c>null</c> caso <paramref name="valor"/> seja nulo.
+    /// </returns>
+    public static string? SomenteAlfanumerico(this string? valor)
+    {
+        if (valor == null) return null;
+
+        var builder = new StringBuilder(valor.Length);
+
+        foreach (var caractere in valor)
+        {
+            if (caractere is >= '0' and <= '9' or >= 'A' and <= 'Z')
+                builder.Append(caractere);
+            else if (caractere is >= 'a' and <= 'z')
+                builder.Append((char)(caractere - 32));
+        }
+
+        return builder.ToString();
+    }
+
+    #endregion Methods
+}

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/DocumentoDeducaoReducao.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/DocumentoDeducaoReducao.cs
@@ -42,16 +42,26 @@ namespace OpenAC.Net.NFSe.Nacional.Common.Model;
 public sealed class DocumentoDeducaoReducao
 {
     /// <summary>
-    /// Chave da NFSe utilizada para dedução/redução (50 dígitos).
+    /// Chave da NFSe utilizada para dedução/redução (50 caracteres). Embute a inscrição federal,
+    /// que pode ser alfanumérica.
     /// </summary>
-    [DFeElement(TipoCampo.StrNumber, "chNFSe", Min = 50, Max = 50, Ocorrencia = Ocorrencia.NaoObrigatoria)]
-    public string? ChaveNFSe { get; set; }
-    
+    [DFeElement(TipoCampo.Str, "chNFSe", Min = 50, Max = 50, Ocorrencia = Ocorrencia.NaoObrigatoria)]
+    public string? ChaveNFSe
+    {
+        get;
+        set => field = value.SomenteAlfanumerico();
+    }
+
     /// <summary>
-    /// Chave da NFe utilizada para dedução/redução (44 dígitos).
+    /// Chave da NFe utilizada para dedução/redução (44 caracteres). Embute a inscrição federal,
+    /// que pode ser alfanumérica.
     /// </summary>
-    [DFeElement(TipoCampo.StrNumber, "chNFSe", Min = 44, Max = 44, Ocorrencia = Ocorrencia.NaoObrigatoria)]
-    public string? ChaveNFe { get; set; }
+    [DFeElement(TipoCampo.Str, "chNFe", Min = 44, Max = 44, Ocorrencia = Ocorrencia.NaoObrigatoria)]
+    public string? ChaveNFe
+    {
+        get;
+        set => field = value.SomenteAlfanumerico();
+    }
     
     /// <summary>
     /// Chave da NFSe do município.
@@ -68,25 +78,25 @@ public sealed class DocumentoDeducaoReducao
     /// <summary>
     /// Número do documento fiscal.
     /// </summary>
-    [DFeElement(TipoCampo.StrNumber, "nDocFisc", Min = 1, Max = 255, Ocorrencia = Ocorrencia.NaoObrigatoria)]
+    [DFeElement(TipoCampo.Str, "nDocFisc", Min = 1, Max = 255, Ocorrencia = Ocorrencia.NaoObrigatoria)]
     public string? NumeroDocumentoFiscal { get; set; }
-    
+
     /// <summary>
     /// Número do documento.
     /// </summary>
-    [DFeElement(TipoCampo.StrNumber, "nDoc", Min = 1, Max = 255, Ocorrencia = Ocorrencia.NaoObrigatoria)]
+    [DFeElement(TipoCampo.Str, "nDoc", Min = 1, Max = 255, Ocorrencia = Ocorrencia.NaoObrigatoria)]
     public string? NumeroDocumento { get; set; }
     
     /// <summary>
     /// Tipo de dedução ou redução.
     /// </summary>
-    [DFeElement(TipoCampo.Enum, "nDoc", Ocorrencia = Ocorrencia.Obrigatoria)]
+    [DFeElement(TipoCampo.Enum, "tpDedRed", Ocorrencia = Ocorrencia.Obrigatoria)]
     public TipoDeducaoReducao TipoDeducaoReducao { get; set; }
     
     /// <summary>
     /// Descrição da dedução ou redução.
     /// </summary>
-    [DFeElement(TipoCampo.StrNumber, "xDescOutDed", Min = 1, Max = 255, Ocorrencia = Ocorrencia.NaoObrigatoria)]
+    [DFeElement(TipoCampo.Str, "xDescOutDed", Min = 1, Max = 255, Ocorrencia = Ocorrencia.NaoObrigatoria)]
     public string? DescricaoReducaoDeducao { get; set; }
     
     /// <summary>

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/Dps.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/Dps.cs
@@ -81,22 +81,41 @@ public sealed class Dps : DFeSignDocument<Dps>
     /// <param name="configuracao">Configuração da NFSe.</param>
     public void Assinar(ConfiguracaoNFSe configuracao)
     {
-        if (Informacoes.Id.IsEmpty())
-        {
-            var tipo = Informacoes.Prestador.CNPJ.IsEmpty() ? "1" : "2";
-            var documneto = Informacoes.Prestador.CPF.IsEmpty()
-                ? Informacoes.Prestador.CNPJ
-                : $"000{Informacoes.Prestador.CPF}";
-
-            Informacoes.Id =
-                $"DPS{Informacoes.LocalidadeEmitente:D7}{tipo}{documneto}{Informacoes.Serie:D5}{Informacoes.NumeroDps:D15}";
-        }
+        GerarId();
 
         var options = DFeSaveOptions.DisableFormatting;
         if (configuracao.Geral.RetirarAcentos)
             options |= DFeSaveOptions.RemoveAccents;
 
         AssinarDocumento(configuracao.Certificados.ObterCertificado(), options, false);
+    }
+
+    /// <summary>
+    /// Gera o identificador da DPS quando ainda não informado. Chamado automaticamente por
+    /// <see cref="Assinar"/>; um <see cref="InfDps.Id"/> já preenchido é preservado.
+    /// </summary>
+    /// <remarks>
+    /// Layout <c>TSIdDPS</c> (45 posições): <c>"DPS"</c> + Cód.Mun.(7) + Tipo Insc.(1) +
+    /// Insc.Federal(14) + Série(5) + Núm.DPS(15). O tipo 1 (CPF) exige 14 dígitos, com <c>000</c> à
+    /// esquerda; o tipo 2 (CNPJ) admite CNPJ alfanumérico. Como todos os campos são
+    /// <see cref="string"/>, o preenchimento é explícito - especificador de formato numérico
+    /// (<c>D7</c>, <c>D5</c>, <c>D15</c>) não se aplica a <see cref="string"/>.
+    /// </remarks>
+    public void GerarId()
+    {
+        if (!Informacoes.Id.IsEmpty()) return;
+
+        var tipo = Informacoes.Prestador.CNPJ.IsEmpty() ? "1" : "2";
+        var documento = Informacoes.Prestador.CPF.IsEmpty()
+            ? Informacoes.Prestador.CNPJ ?? string.Empty
+            : $"000{Informacoes.Prestador.CPF}";
+
+        Informacoes.Id = "DPS" +
+                         Informacoes.LocalidadeEmitente.PadLeft(7, '0') +
+                         tipo +
+                         documento.PadLeft(14, '0') +
+                         Informacoes.Serie.PadLeft(5, '0') +
+                         Informacoes.NumeroDps.PadLeft(15, '0');
     }
 
     #endregion Methods

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/EmitenteNFSe.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/EmitenteNFSe.cs
@@ -42,10 +42,14 @@ public sealed class EmitenteNFSe
     #region Properties
 
     /// <summary>
-    /// CNPJ do emitente.
+    /// CNPJ do emitente. Aceita CNPJ alfanumérico; a formatação informada é descartada.
     /// </summary>
-    [DFeElement(TipoCampo.StrNumber, "CNPJ", Min = 14, Max = 14, Ocorrencia = Ocorrencia.NaoObrigatoria)]
-    public string? CNPJ { get; set; }
+    [DFeElement(TipoCampo.Str, "CNPJ", Min = 14, Max = 14, Ocorrencia = Ocorrencia.NaoObrigatoria)]
+    public string? CNPJ
+    {
+        get;
+        set => field = value.SomenteAlfanumerico();
+    }
     
     /// <summary>
     /// CPF do emitente.

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/EventoDesbloqueioOficio.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/EventoDesbloqueioOficio.cs
@@ -52,8 +52,13 @@ public sealed class EventoDesbloqueioOficio : IEventoNFSe
     public string CPFAgTrib { get; set; } = string.Empty;
 
     /// <summary>
-    /// Código de manifestação do evento de desbloqueio por ofício.
+    /// Código de manifestação do evento de desbloqueio por ofício. Embute a inscrição federal,
+    /// que pode ser alfanumérica.
     /// </summary>
-    [DFeElement(TipoCampo.StrNumber, "idBloqOfic", Min = 59, Max = 59, Ocorrencia = Ocorrencia.Obrigatoria)]
-    public string CodManifestacaoEvento { get; set; } = string.Empty;
+    [DFeElement(TipoCampo.Str, "idBloqOfic", Min = 59, Max = 59, Ocorrencia = Ocorrencia.Obrigatoria)]
+    public string CodManifestacaoEvento
+    {
+        get;
+        set => field = value.SomenteAlfanumerico() ?? string.Empty;
+    } = string.Empty;
 }

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/InfPedReg.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/InfPedReg.cs
@@ -69,10 +69,14 @@ public sealed class InfPedReg
     public DateTimeOffset DhEvento { get; set; }
     
     /// <summary>
-    /// CNPJ do autor do evento.
+    /// CNPJ do autor do evento. Aceita CNPJ alfanumérico; a formatação informada é descartada.
     /// </summary>
-    [DFeElement(TipoCampo.StrNumber, "CNPJAutor", Min = 14, Max = 14, Ocorrencia = Ocorrencia.NaoObrigatoria)]
-    public string? CNPJAutor { get; set; }
+    [DFeElement(TipoCampo.Str, "CNPJAutor", Min = 14, Max = 14, Ocorrencia = Ocorrencia.NaoObrigatoria)]
+    public string? CNPJAutor
+    {
+        get;
+        set => field = value.SomenteAlfanumerico();
+    }
     
     /// <summary>
     /// CPF do autor do evento.

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/InfoAnulacaoRejeicao.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/InfoAnulacaoRejeicao.cs
@@ -46,10 +46,14 @@ public sealed class InfoAnulacaoRejeicao
     public string CPFAgTrib { get; set; } = string.Empty;
     
     /// <summary>
-    /// Código do manifesto de rejeição.
+    /// Código do manifesto de rejeição. Embute a inscrição federal, que pode ser alfanumérica.
     /// </summary>
-    [DFeElement(TipoCampo.StrNumber, "idEvManifRej", Min = 59, Max = 59, Ocorrencia = Ocorrencia.Obrigatoria)]
-    public string CodManifestoRejeicao { get; set; } = string.Empty;
+    [DFeElement(TipoCampo.Str, "idEvManifRej", Min = 59, Max = 59, Ocorrencia = Ocorrencia.Obrigatoria)]
+    public string CodManifestoRejeicao
+    {
+        get;
+        set => field = value.SomenteAlfanumerico() ?? string.Empty;
+    } = string.Empty;
     
     /// <summary>
     /// Motivo da anulação ou rejeição.

--- a/src/OpenAC.Net.NFSe.Nacional/Common/Model/InfoPessoaNFSe.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/Model/InfoPessoaNFSe.cs
@@ -43,10 +43,14 @@ public class InfoPessoaNFSe
     #region Properties
 
     /// <summary>
-    /// CNPJ da pessoa.
+    /// CNPJ da pessoa. Aceita CNPJ alfanumérico; a formatação informada é descartada.
     /// </summary>
-    [DFeElement(TipoCampo.StrNumber, "CNPJ", Min = 14, Max = 14, Ocorrencia = Ocorrencia.NaoObrigatoria, Ordem = 0)]
-    public string? CNPJ { get; set; }
+    [DFeElement(TipoCampo.Str, "CNPJ", Min = 14, Max = 14, Ocorrencia = Ocorrencia.NaoObrigatoria, Ordem = 0)]
+    public string? CNPJ
+    {
+        get;
+        set => field = value.SomenteAlfanumerico();
+    }
 
     /// <summary>
     /// CPF da pessoa.

--- a/src/OpenAC.Net.NFSe.Nacional/Schemas/1.01/tiposSimples_v1.01.xsd
+++ b/src/OpenAC.Net.NFSe.Nacional/Schemas/1.01/tiposSimples_v1.01.xsd
@@ -31,27 +31,27 @@
   <xs:simpleType name="TSIdNFSe">
     <xs:annotation>
       <xs:documentation>
-        Informar o identificador precedido do literal ‘NFS’. A regra de formação do identificador de 53 posições da NFS-e é:
+        Informar o identificador precedido do literal "NFS". A regra de formação do identificador de 53 posições da NFS-e é:
         "NFS" + Cód.Mun.(7) + Amb.Ger.(1) + Tipo de Inscrição Federal(1) + Inscrição Federal(14) + No.NFS-e(13) + AnoMes Emis.(4) + Cód.Num.(9) + DV(1)
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:whiteSpace value="preserve"/>
       <xs:maxLength value="53"/>
-      <xs:pattern value="NFS[0-9]{50}"/>
+      <xs:pattern value="NFS[0-9]{9}[0-9A-Z]{14}[0-9]{27}"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSIdDPS">
     <xs:annotation>
       <xs:documentation>
-        Informar o identificador precedido do literal ‘DPS’. A regra de formação do identificador de 45 posições da DPS é:
+        Informar o identificador precedido do literal "DPS". A regra de formação do identificador de 45 posições da DPS é:
         "DPS" + Cód.Mun (7) + Tipo de Inscrição Federal (1) + Inscrição Federal (14 - CPF completar com 000 à esquerda) + Série DPS (5)+ Núm. DPS (15)
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:whiteSpace value="preserve"/>
       <xs:maxLength value="45"/>
-      <xs:pattern value="DPS[0-9]{42}"/>
+      <xs:pattern value="DPS[0-9]{7}(1[0-9]{14}|2[0-9A-Z]{14})[0-9]{20}"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSTipoAmbiente">
@@ -143,7 +143,7 @@
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:whiteSpace value="preserve"/>
-      <xs:pattern value="(((20(([02468][048])|([13579][26]))-02-29))|(20[0-9][0-9])-((((0[1-9])|(1[0-2]))-((0[1-9])|(1\d)|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[1,3-9])|(1[0-2]))-(29|30)))))T(20|21|22|23|[0-1]\d):[0-5]\d:[0-5]\d([\-,\+](0[0-9]|10|11):00|([\+](12):00))"/>
+      <xs:pattern value="(((20(([02468][048])|([13579][26]))-02-29))|(20[0-9][0-9])-((((0[1-9])|(1[0-2]))-((0[1-9])|(1\d)|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[13-9])|(1[0-2]))-(29|30)))))T(20|21|22|23|[0-1]\d):[0-5]\d:[0-5]\d([-+](0[0-9]|10|11):00|([\+](12):00))"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSVerAplic">
@@ -158,8 +158,8 @@
   <xs:simpleType name="TSSerieDPS">
     <xs:restriction base="xs:string">
       <xs:maxLength value="5"/>
-      <xs:pattern value="^0{0,4}\d{1,5}$"/>
-      <xs:whiteSpace value="preserve"/>
+        <xs:pattern value="[0-9]{1,4}|[0-8][0-9]{4}"/>
+        <xs:whiteSpace value="preserve"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSEmitenteDPS">
@@ -203,7 +203,7 @@
     <xs:restriction base="xs:string">
       <xs:whiteSpace value="preserve"/>
       <xs:maxLength value="50"/>
-      <xs:pattern value="[0-9]{50}"/>
+      <xs:pattern value="[0-9]{6}([0-9A-Z]{14})[0-9]{30}"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSChaveNFe">
@@ -213,7 +213,7 @@
     <xs:restriction base="xs:string">
       <xs:whiteSpace value="preserve"/>
       <xs:maxLength value="44"/>
-      <xs:pattern value="[0-9]{44}"/>
+      <xs:pattern value="[0-9]{6}([0-9A-Z]{14})[0-9]{24}"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSCodJustCanc">
@@ -361,7 +361,7 @@
     <xs:restriction base="xs:string">
       <xs:whiteSpace value="preserve"/>
       <xs:maxLength value="14"/>
-      <xs:pattern value="[0-9]{14}"/>
+      <xs:pattern value="[0-9A-Z]{14}"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSCPF">
@@ -896,6 +896,7 @@
       <xs:whiteSpace value="preserve"/>
       <xs:minLength value="1"/>
       <xs:maxLength value="2000"/>
+	  <xs:pattern value="[\s\S]*[^\s][\s\S]*"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSCodVerificacao">
@@ -917,7 +918,7 @@
   <xs:simpleType name="TSIdeDedRed">
     <xs:annotation>
       <xs:documentation>
-	Identificação da Dedução/Redução:
+  Identificação da Dedução/Redução:
         1 – Alimentação e bebidas/frigobar;
         2 – Materiais;
         3 - Produção Externa;
@@ -1232,16 +1233,16 @@
     <xs:annotation>
       <xs:documentation>
         Tipo de retencao do Pis/Cofins:
-	0 - PIS/COFINS/CSLL Não Retidos;
-	1 - PIS/COFINS Retidos;
-	2 - PIS/COFINS Não Retidos;
-	3 - PIS/COFINS/CSLL Retidos;
-	4 - PIS/COFINS Retidos, CSLL Não Retido;
-	5 - PIS Retido, COFINS/CSLL Não Retido;
-	6 - COFINS Retido, PIS/CSLL Não Retido;
-	7 - PIS Não Retido, COFINS/CSLL Retidos;
-	8 - PIS/COFINS Não Retidos, CSLL Retido;
-	9 - COFINS Não Retido, PIS/CSLL Retidos;
+  0 - PIS/COFINS/CSLL Não Retidos;
+  1 - PIS/COFINS Retidos;
+  2 - PIS/COFINS Não Retidos;
+  3 - PIS/COFINS/CSLL Retidos;
+  4 - PIS/COFINS Retidos, CSLL Não Retido;
+  5 - PIS Retido, COFINS/CSLL Não Retido;
+  6 - COFINS Retido, PIS/CSLL Não Retido;
+  7 - PIS Não Retido, COFINS/CSLL Retidos;
+  8 - PIS/COFINS Não Retidos, CSLL Retido;
+  9 - COFINS Não Retido, PIS/CSLL Retidos;
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -1287,7 +1288,7 @@
       <xs:enumeration value="2"/>
       <xs:enumeration value="3"/>
       <xs:enumeration value="4"/>
-	</xs:restriction>
+  </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TStat">
     <xs:annotation>
@@ -1388,12 +1389,14 @@
     <xs:restriction base="TSString">
       <xs:minLength value="1"/>
       <xs:maxLength value="40"/>
+	  <xs:pattern value="[\s\S]*[^\s][\s\S]*"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSDesc150">
     <xs:restriction base="TSString">
       <xs:minLength value="1"/>
       <xs:maxLength value="150"/>
+	  <xs:pattern value="[\s\S]*[^\s][\s\S]*"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSDesc255">
@@ -1401,6 +1404,7 @@
       <xs:whiteSpace value="preserve"/>
       <xs:minLength value="1"/>
       <xs:maxLength value="255"/>
+	  <xs:pattern value="[\s\S]*[^\s][\s\S]*"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSDesc600">
@@ -1408,6 +1412,7 @@
       <xs:whiteSpace value="preserve"/>
       <xs:minLength value="1"/>
       <xs:maxLength value="600"/>
+	  <xs:pattern value="[\s\S]*[^\s][\s\S]*"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSDesc500">
@@ -1415,19 +1420,22 @@
       <xs:whiteSpace value="preserve"/>
       <xs:minLength value="1"/>
       <xs:maxLength value="500"/>
+	  <xs:pattern value="[\s\S]*[^\s][\s\S]*"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSDesc1000">
     <xs:restriction base="TSString">
       <xs:minLength value="1"/>
       <xs:maxLength value="1000"/>
+	  <xs:pattern value="[\s\S]*[^\s][\s\S]*"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSDesc2000">
     <xs:restriction base="TSStringComQuebraDeLinha">
       <xs:minLength value="1"/>
       <xs:maxLength value="2000"/>
-    </xs:restriction>
+	  <xs:pattern value="[\s\S]*[^\s][\s\S]*"/>
+	</xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSDec15V2">
     <xs:annotation>
@@ -1505,35 +1513,35 @@
       <xs:pattern value="[0-9]{15}"/>
     </xs:restriction>
   </xs:simpleType>
-  <xs:simpleType name="TSIdPedRegEvt">
-    <xs:annotation>
-      <xs:documentation>
-        O identificador do pedido de registro do evento é formado conforme a concatenação dos seguintes campos:
+    <xs:simpleType name="TSIdPedRegEvt">
+      <xs:annotation>
+        <xs:documentation>
+          O identificador do pedido de registro do evento é formado conforme a concatenação dos seguintes campos:
         "PRE" + Chave de Acesso NFS-e + Tipo do evento + Número do Pedido de Registro do Evento (nPedRegEvento)
-      </xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:whiteSpace value="preserve"/>
-      <xs:maxLength value="59"/>
-      <xs:pattern value="PRE[0-9]{56}"/>
-    </xs:restriction>
-  </xs:simpleType>
+        </xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+        <xs:whiteSpace value="preserve"/>
+        <xs:maxLength value="59"/>
+        <xs:pattern value="PRE[0-9]{8}(1[0-9]{14}|2[0-9A-Z]{14})[0-9]{33}"/>
+      </xs:restriction>
+    </xs:simpleType>
   <xs:simpleType name="TSIdEvento">
     <xs:annotation>
       <xs:documentation>
-	Identificador do evento: "EVT" + Chave de acesso(50) Tipo do evento (6) + Pedido de Registro do Evento(3) (nPedRegEvento)
+	      Identificador do evento: "EVT" + Chave de acesso(50) Tipo do evento (6) + Pedido de Registro do Evento(3) (nPedRegEvento)
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:whiteSpace value="preserve"/>
       <xs:maxLength value="62"/>
-      <xs:pattern value="EVT[0-9]{59}"/>
+      <xs:pattern value="EVT[0-9]{8}(1[0-9]{14}|2[0-9A-Z]{14})[0-9]{36}"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSCodigoEventoNFSe">
     <xs:annotation>
       <xs:documentation>
-	Código de evento da NFS-e
+        Código de evento da NFS-e
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -1547,18 +1555,18 @@
   <xs:simpleType name="TSIdNumEvento">
     <xs:annotation>
       <xs:documentation>
-	Referência ao Id "Manifestação de rejeição da NFS-e" que originou o presente evento de anulação.
+        Referência ao Id "Manifestação de rejeição da NFS-e" que originou o presente evento de anulação.
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:whiteSpace value="preserve"/>
-      <xs:pattern value="[0-9]{59}"/>
+      <xs:pattern value="[0-9]{8}(1[0-9]{14}|2[0-9A-Z]{14})[0-9]{33}"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSNumDFe">
     <xs:annotation>
       <xs:documentation>
-	Número sequencial do documento gerado por ambiente gerador de DFe do município.
+  Número sequencial do documento gerado por ambiente gerador de DFe do município.
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -1590,7 +1598,7 @@
   <xs:simpleType name="TSSituacaoEmissaoNFSE">
     <xs:annotation>
       <xs:documentation>
-	Situação Emissão NFS-e:
+  Situação Emissão NFS-e:
         0 - Não Habilitado;
         1 - Habilitado;
       </xs:documentation>
@@ -1604,7 +1612,7 @@
   <xs:simpleType name="TSCategoriaServico">
     <xs:annotation>
       <xs:documentation>
-	Categorias do serviço:
+  Categorias do serviço:
         1 - Locação;
         2 - Sublocação;
         3 - Arrendamento;

--- a/src/OpenAC.Net.NFSe.Nacional/Schemas/1.01/xmldsig-core-schema.xsd
+++ b/src/OpenAC.Net.NFSe.Nacional/Schemas/1.01/xmldsig-core-schema.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <!-- Schema for XML Signatures
     http://www.w3.org/2000/09/xmldsig#
     $Revision: 1.2 $ on $Date: 2013-04-16 12:48:49 $ by $Author: denis $


### PR DESCRIPTION
O `tiposSimples_v1.01.xsd` foi atualizado para a versão oficial mais recente, em que
`TSCNPJ` passou de `[0-9]{14}` para `[0-9A-Z]{14}`. A mudança se propaga para todas as
chaves e identificadores que embutem a inscrição federal (`TSChaveNFSe`, `TSChaveNFe`,
`TSIdDPS`, `TSIdNFSe`, `TSIdPedRegEvt`, `TSIdEvento`, `TSIdNumEvento`).

Os campos correspondentes eram serializados com `TipoCampo.StrNumber`, que descarta
qualquer caractere não numérico — um CNPJ alfanumérico era gravado sem as letras,
silenciosamente, gerando XML inválido. Campos ajustados:

- `EmitenteNFSe.CNPJ`, `InfoPessoaNFSe.CNPJ` (e `PrestadorDps`), `InfPedReg.CNPJAutor`
- `DocumentoDeducaoReducao.ChaveNFSe` e `ChaveNFe`
- `InfoAnulacaoRejeicao.CodManifestoRejeicao`, `EventoDesbloqueioOficio.CodManifestacaoEvento`

A limpeza de formatação foi preservada: valores como `12.ABC.678/0001-99` continuam
sendo normalizados automaticamente para `12ABC678000199`.

### 🐛 Correções

- **Id da DPS gerado com tamanho inválido.** Os campos são `string` e os especificadores
  de formato (`D7`, `D5`, `D15`) não se aplinos de 45
  posições e não casava com `TSIdDPS`. A montagem agora é explícita e cobre os dois
  ramos (CPF → tipo `1`, CNPJ → tipo `2`).
- **`DocumentoDeducaoReducao`: nomes de elemento divergentes do `TCDocDedRed`.**
  `ChaveNFe` era gravada como `<chNFSe>` (agReducao` como
  `<nDoc>`, colidindo com `NumeroDocumento` (agora `<tpDedRed>`).
- **`DocumentoDeducaoReducao`: campos de tex*
  `xDescOutDed`, `nDocFisc` e `nDoc` usavam `StrNumber` e perdiam todas as letras — uma
  descrição como `"Reembolso de despesas"` e

### ✨ Novidades

- `Dps.GerarId()` — geração do identificadorua sendo
  chamada automaticamente por `Assinar()` e preserva um `Id` já informado.

### ✅ Testes

- Nova suíte `TestSchemaV101` com testes **offline**: cobrem serialização com CNPJ
  alfanumérico, validação contra o `DPS_v1.0nomes de
  elemento do `docDedRed`. Não exigem `.env`, certificado digital nem acesso aos
  webservices.

~~~xml
<toma>
<CNPJ>12ABC34501DE35</CNPJ>
<xNome>EXEMPLO CNPJ ALFA</xNome>
<end>
	<endNac>
		<cMun>3547809</cMun>
		<CEP>09090401</CEP>
	</endNac>
	<xLgr>Rua  CATEQUESE</xLgr>
	<nro>227</nro>
	<xCpl>ANDAR 11 SALA 111</xCpl>
	<xBairro>JARDIM</xBairro>
</end>
<fone>1121911000</fone>
<email>fiscal@cvc.com.br</email>
</toma>
~~~

### Evidencia
O CNPJ foi transmitido mas como não existem CNPJ reais ainda, deu erro de CNPJ Não encontrado.
~~~ json
[{\"Codigo\":\"E0190\",\"Descricao\":\"CNPJ do tomador não encontrado no cadastro CNPJ.\"}]
~~~