### PR TITLE
feat: Adiciona propriedade AssinarXml para controle da assinatura do XML

### DIFF
--- a/src/OpenAC.Net.NFSe.Nacional/Common/NFSeGeralConfig.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Common/NFSeGeralConfig.cs
@@ -47,5 +47,10 @@ public sealed class NFSeGeralConfig : DFeGeralConfigBase
     /// <value>A versão da NFSe.</value>
     public VersaoNFSe Versao { get; set; } = VersaoNFSe.Ve100;
 
+    /// <summary>
+    /// Define se deve assinar o xml ou se sera recebido assinado.
+    /// </summary>
+    public bool AssinarXml { get; set; } = true;
+
     #endregion Properties
 }

--- a/src/OpenAC.Net.NFSe.Nacional/Webservice/Nacional/NacionalWebservice.cs
+++ b/src/OpenAC.Net.NFSe.Nacional/Webservice/Nacional/NacionalWebservice.cs
@@ -29,6 +29,7 @@
 // <summary></summary>
 // ***********************************************************************
 
+using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -188,7 +189,8 @@ public class NacionalWebservice : NFSeWebserviceBase
     /// <returns>Resposta do envio do evento.</returns>
     public override async Task<NFSeResponse<RespostaEnvioEvento>> EnviarEventoAsync(PedidoRegistroEvento evento)
     {
-        evento.Assinar(Configuracao);
+        if (Configuracao.Geral.AssinarXml)
+            evento.Assinar(Configuracao);
 
         ValidarSchema(SchemaNFSe.Evento, evento.Xml, evento.Versao);
 
@@ -283,7 +285,13 @@ public class NacionalWebservice : NFSeWebserviceBase
     /// <returns>Resposta do envio da DPS.</returns>
     public override async Task<NFSeResponse<RespostaEnvioDps>> EnviarAsync(Dps dps)
     {
-        dps.Assinar(Configuracao);
+        if (Configuracao.Geral.AssinarXml)
+        {
+            Console.WriteLine("Assinando DPS");
+            dps.Assinar(Configuracao);
+        }
+        else
+            Console.WriteLine("SKIP assinatura DPS");
 
         ValidarSchema(SchemaNFSe.DPS, dps.Xml, dps.Versao);
 


### PR DESCRIPTION
## Resumo das Alterações

### Adição de configuração para controle da assinatura do XML (`AssinarXml`)

Foi adicionada uma nova propriedade de configuração na classe `NFSeGeralConfig` para permitir habilitar ou desabilitar condicionalmente a assinatura digital do XML antes do envio aos webservices da NFS-e Nacional.

Essa configuração permite que a assinatura seja realizada externamente à biblioteca, quando necessário, evitando que um XML que já foi assinado seja assinado novamente durante o envio.

## Cenário de uso — Assinatura realizada no cliente

Em aplicações web que utilizam certificados **A3**, a assinatura digital pode precisar ser realizada na máquina do cliente, onde o certificado está instalado e disponível.

Nesse cenário, a aplicação pode gerar o XML da DPS no servidor, enviá-lo para o cliente para assinatura e, posteriormente, receber o XML já assinado para realizar o envio à NFS-e Nacional.

### Fluxo

1. **Usuário:** Solicita a emissão da NFS-e.
2. **API:** Configura `AssinarXml = false`.
3. **API:** Gera a DPS e obtém o XML.
4. **API → Cliente:** Envia o XML para a máquina do cliente.
5. **Cliente:** Realiza a assinatura digital utilizando o certificado A3.
6. **Cliente → API:** Envia o XML já assinado de volta para a API.
7. **API:** Gera novamente a DPS a partir do XML assinado.
8. **API:** Invoca `webservice.Enviar(dps)`.
9. **Biblioteca:** Como `AssinarXml = false`, não realiza uma nova assinatura do XML.

> Para transmissão será utilizado o certificado digital da Software House (Já foi testado).

### Resultado esperado

A configuração `AssinarXml = false` permite que a biblioteca receba e envie um XML que já foi assinado externamente, sem sobrescrever ou duplicar o processo de assinatura.

Dessa forma, o fluxo de assinatura com certificado A3 pode ser realizado na máquina do cliente, enquanto a geração e o envio da NFS-e permanecem sob responsabilidade da aplicação/API.
